### PR TITLE
reformat comfirmation email

### DIFF
--- a/templates/user/verify.html
+++ b/templates/user/verify.html
@@ -1,9 +1,141 @@
-<p>
-  Welcome {{ name }}! Thanks for signing up. Please follow this link to activate your
-  account for {{ email }}:
-</p>
-<p>
-  <a href="{{ verify_url }}">{{ verify_url }}</a>
-</p>
-<br />
-<p>Cheers!</p>
+<!DOCTYPE html>
+<html> 
+
+<head>
+    <title></title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <style type="text/css">
+        body,
+        table,
+        td,
+        a {
+            -webkit-text-size-adjust: 100%;
+            -ms-text-size-adjust: 100%;
+        }
+
+        table,
+        td {
+            mso-table-lspace: 0pt;
+            mso-table-rspace: 0pt;
+        }
+
+        img {
+            -ms-interpolation-mode: bicubic;
+        }
+
+        /* RESET STYLES */
+        img {
+            border: 0;
+            height: auto;
+            line-height: 100%;
+            outline: none;
+            text-decoration: none;
+        }
+
+        table {
+            border-collapse: collapse !important;
+        }
+
+        body {
+            height: 100% !important;
+            margin: 0 !important;
+            padding: 0 !important;
+            width: 100% !important;
+        }
+
+        /* iOS BLUE LINKS */
+        a[x-apple-data-detectors] {
+            color: inherit !important;
+            text-decoration: none !important;
+            font-size: inherit !important;
+            font-family: inherit !important;
+            font-weight: inherit !important;
+            line-height: inherit !important;
+        }
+
+        /* MOBILE STYLES */
+        @media screen and (max-width:600px) {
+            h1 {
+                font-size: 32px !important;
+                line-height: 32px !important;
+            }
+        }
+
+        /* ANDROID CENTER FIX */
+        div[style*="margin: 16px 0;"] {
+            margin: 0 !important;
+        }
+    </style>
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans&family=Roboto:ital,wght@1,500&display=swap" rel="stylesheet"> 
+
+    <style>
+        body {
+          font-family: 'Roboto', sans-serif;
+        }
+      </style>
+</head>
+
+<body style="background-color: #f4f4f4; margin: 0 !important; padding: 0 !important;">
+    <!-- HIDDEN PREHEADER TEXT -->
+    <div style="display: none; font-size: 1px; color: #fefefe; line-height: 1px;max-height: 0px; max-width: 0px; opacity: 0; overflow: hidden;"> We're thrilled to have you here! Get ready to dive into your new account. </div>
+    <table border="0" cellpadding="0" cellspacing="0" width="100%">
+        <tr>
+            <td bgcolor="#f4f4f4" align="center" style="padding: 0px 10px 0px 10px;">
+                <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px;">
+                    <tr>
+                        <td bgcolor="#ffffff" align="center" valign="top" style="padding: 5px 15px 30px 15px; border-radius: 4px 4px 0px 0px; color: #111111; font-family: 'Roboto', Helvetica, Arial, sans-serif; font-size: 48px; font-weight: 400; letter-spacing: 4px; line-height: 48px;">
+                             <img src="https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcRzkuTpE0q2DJnKC3XJMbmMUA_WZRYcBlefOHSmgMp71IukHAgx&usqp=CAU" width="150" height="100" style="display: block; border: 0px;" />
+                             <h1 style="font-size: 48px; font-weight: 400; margin: 2;">{{ name }}!</h1>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+        <tr>
+            <td bgcolor="#f4f4f4" align="center" style="padding: 0px 10px 0px 10px;">
+                <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px;">
+                    <tr>
+                    
+                        <td bgcolor="#ffffff" align="left" style="padding: 5px 15px 30px 15px; color: #666666; font-family: 'Roboto', Helvetica, Arial, sans-serif; font-size: 18px; font-weight: 400; line-height: 25px;">
+                            <p style="margin: 0;"> We're thrilled to have you become apart of Crane Cloud! Get ready to dive into your new account. Let's help you get started. First, you need to confirm your account. Just press the button below.</p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td bgcolor="#ffffff" align="left">
+                            <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                                <tr>
+                                    <td bgcolor="#ffffff" align="center" style="padding: 5px 15px 30px 15px;">
+                                        <table border="0" cellspacing="0" cellpadding="0">
+                                            <tr>
+                                                <td align="center" style="border-radius: 3px;" bgcolor="#008AC1"><a href="{{ verify_url }}" target="_blank" style="font-size: 20px; font-family: 'Roboto', Arial, sans-serif; color: #ffffff; text-decoration: none; color: #ffffff; text-decoration: none; padding: 15px 25px; border-radius: 2px; border: 1px solid #008AC1; display: inline-block;">Confirm Account</a></td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr> 
+                    <tr>
+                        <td bgcolor="#ffffff" align="left" style="padding: 0px 30px 0px 30px; color: #666666; font-family: 'Roboto', Helvetica, Arial, sans-serif; font-size: 18px; font-weight: 400; line-height: 25px;">
+                            <p style="margin: 0;">If that doesn't work, copy and paste the following link in your browser:</p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td bgcolor="#ffffff" align="left" style="padding: 20px 30px 20px 30px; color: #666666; font-family: 'Roboto', Helvetica, Arial, sans-serif; font-size: 16px; font-weight: 400; line-height: 25px;">
+                            <p style="margin: 0;"><a href="#" target="_blank" style="color: #008AC1;">{{ verify_url }}</a></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td bgcolor="#ffffff" align="left" style="padding: 0px 30px 40px 30px; border-radius: 0px 0px 4px 4px; color: #666666; font-family: 'Roboto', Helvetica, Arial, sans-serif; font-size: 18px; font-weight: 400; line-height: 25px;">
+                            <p style="margin: 0;">Cheers !<br>Crane Cloud Team</p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+
+</html>

--- a/templates/user/verify.html
+++ b/templates/user/verify.html
@@ -99,7 +99,7 @@
                     <tr>
                     
                         <td bgcolor="#ffffff" align="left" style="padding: 5px 15px 30px 15px; color: #666666; font-family: 'Roboto', Helvetica, Arial, sans-serif; font-size: 18px; font-weight: 400; line-height: 25px;">
-                            <p style="margin: 0;"> We're thrilled to have you become apart of Crane Cloud! Get ready to dive into your new account. Let's help you get started. First, you need to confirm your account. Just press the button below.</p>
+                            <p style="margin: 0;"> We're thrilled to have you become a part of Crane Cloud! Get ready to dive into your new account. Let's help you get started. First, you need to confirm your account. Just press the button below.</p>
                         </td>
                     </tr>
                     <tr>

--- a/templates/user/verify.html
+++ b/templates/user/verify.html
@@ -87,7 +87,7 @@
                     <tr>
                         <td bgcolor="#ffffff" align="center" valign="top" style="padding: 5px 15px 30px 15px; border-radius: 4px 4px 0px 0px; color: #111111; font-family: 'Roboto', Helvetica, Arial, sans-serif; font-size: 48px; font-weight: 400; letter-spacing: 4px; line-height: 48px;">
                              <img src="https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcRzkuTpE0q2DJnKC3XJMbmMUA_WZRYcBlefOHSmgMp71IukHAgx&usqp=CAU" width="150" height="100" style="display: block; border: 0px;" />
-                             <h1 style="font-size: 48px; font-weight: 400; margin: 2;">{{ name }}!</h1>
+                             <h1 style="font-size: 48px; font-weight: 400; margin: 2;">{{ name }}</h1>
                         </td>
                     </tr>
                 </table>
@@ -99,7 +99,7 @@
                     <tr>
                     
                         <td bgcolor="#ffffff" align="left" style="padding: 5px 15px 30px 15px; color: #666666; font-family: 'Roboto', Helvetica, Arial, sans-serif; font-size: 18px; font-weight: 400; line-height: 25px;">
-                            <p style="margin: 0;"> We're thrilled to have you become a part of Crane Cloud! Get ready to dive into your new account. Let's help you get started. First, you need to confirm your account. Just press the button below.</p>
+                            <p style="margin: 0;"> We're thrilled to have you become a part of Crane Cloud. Get ready to dive into your new account. Let's help you get started. First, you need to confirm your account. Just press the button below.</p>
                         </td>
                     </tr>
                     <tr>


### PR DESCRIPTION
### What does this PR do?
It reformats the email  for activate account. 

- Proper formatting
- use cranecloud fonts {Roboto}
- Add a confirm button 

### Need help on

- I have failed to find where the header is set to **no-reply** 

- ideas on how best to add the logo (if i store it within the api it doesnt display in the email)

- any other feedback concerning how to improve this feature is also welcome

### How to test
Run this branch locally and register a new user then check for the nature of email

### Screenshots 
![Screenshot from 2020-04-22 15-17-41](https://user-images.githubusercontent.com/36065782/79980925-7d522c00-84ac-11ea-885f-8e7b7ab853e9.png)
![Screenshot from 2020-04-22 15-16-11](https://user-images.githubusercontent.com/36065782/79980763-48de7000-84ac-11ea-84f9-64c9c757b808.png)








