### PR TITLE
feat: add enpoint for project network request metrics

### DIFF
--- a/api_docs.yml
+++ b/api_docs.yml
@@ -1826,6 +1826,46 @@ paths:
                 500:
                     description: "Internal Server Error"
 
+    "/projects/{project_id}/metrics/network":
+        post:
+            tags:
+                - projects
+            consumes:
+                - application/json
+            produces:
+                - application/json
+            parameters:
+                - in: header
+                  name: Authorization
+                  required: true
+                  type: string
+                - in: path
+                  name: project_id
+                  required: true
+                  type: string
+                - in: body
+                  name: project metrics
+                  schema:
+                    properties:
+                        start:
+                            type: number
+                            format: float
+                        end:
+                            type: number
+                            format: float
+                        step:
+                            type: string
+
+            responses:
+                200:
+                    description: "Network metrics for a single Project"
+                404:
+                    description: "Project metrics not found"
+                400:
+                    description: "Bad request"
+                500:
+                    description: "Internal Server Error"
+                
 
     "/apps":
 

--- a/app/controllers/__init__.py
+++ b/app/controllers/__init__.py
@@ -22,6 +22,6 @@ from .organisation_admins import OrgAdminView
 from .organisation_members import OrgMemberView
 from .project import (
     ProjectsView, ProjectDetailView, UserProjectsView,
-    ProjectCPUView, ProjectMemoryUsageView)
+    ProjectCPUView, ProjectMemoryUsageView, ProjectNetworkRequestView)
 from .app import AppsView, ProjectAppsView, AppDetailView, AppCpuUsageView, AppMemoryUsageView
 from .registry import RegistriesView

--- a/app/controllers/project.py
+++ b/app/controllers/project.py
@@ -442,7 +442,7 @@ class ProjectNetworkRequestView(Resource):
             start=start,
             end=end,
             step=step,
-            metric='sum(rate(container_cpu_usage_seconds_total{container!="POD", image!="",namespace="' +
+            metric='sum(rate(container_network_receive_bytes_total{namespace="' +
             namespace+'"}[5m]))'
         )
         #  chenge array values to json"values"

--- a/app/controllers/project.py
+++ b/app/controllers/project.py
@@ -400,3 +400,60 @@ class ProjectCPUView(Resource):
             return dict(status='fail', message='No values found'), 404
 
         return dict(status='success', data=dict(values=cpu_data_list)), 200
+
+class ProjectNetworkRequestView(Resource):
+    @jwt_required
+    def post(self, project_id):
+        current_user_id = get_jwt_identity()
+        current_user_roles = get_jwt_claims()['roles']
+
+        project_network_schema = MetricsSchema()
+        project_network_data = request.get_json()
+
+        validated_query_data, errors = project_network_schema.load(
+            project_network_data)
+
+        if errors:
+            return dict(status='fail', message=errors), 400
+
+        project = Project.get_by_id(project_id)
+
+        if not project:
+            return dict(
+                status='fail',
+                message=f'project {project_id} not found'
+            ), 404
+
+        if not is_owner_or_admin(project, current_user_id, current_user_roles):
+            return dict(status='fail', message='unauthorised'), 403
+
+        # Get current time
+        current_time = datetime.datetime.now()
+        yesterday = current_time + datetime.timedelta(days=-1)
+        namespace = project.alias
+
+        prometheus = Prometheus()
+
+        start = validated_query_data.get('start', yesterday.timestamp())
+        end = validated_query_data.get('end', current_time.timestamp())
+        step = validated_query_data.get('step', '1h')
+
+        prom_data = prometheus.query_rang(
+            start=start,
+            end=end,
+            step=step,
+            metric='sum(rate(container_cpu_usage_seconds_total{container!="POD", image!="",namespace="' +
+            namespace+'"}[5m]))'
+        )
+        #  chenge array values to json"values"
+        new_data = json.loads(prom_data)
+        network_data_list = []
+
+        try:
+            for value in new_data["data"]["result"][0]["values"]:
+                case = {'timestamp': float(value[0]), 'value': float(value[1])}
+                network_data_list.append(case)
+        except:
+            return dict(status='fail', message='No values found'), 404
+
+        return dict(status='success', data=dict(values=network_data_list)), 200

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -13,7 +13,7 @@ from app.controllers import (
     ProjectsView, ProjectDetailView, UserProjectsView, UserEmailVerificationView,
     EmailVerificationRequest, ForgotPasswordView, ResetPasswordView, AppsView, UserDetailView, AdminLoginView,
     ProjectAppsView, AppDetailView, RegistriesView, ProjectMemoryUsageView, ProjectCPUView, AppMemoryUsageView,
-    AppCpuUsageView
+    AppCpuUsageView, ProjectNetworkRequestView
 )
 
 api = Api()
@@ -86,6 +86,7 @@ api.add_resource(ProjectDetailView, '/projects/<string:project_id>')
 api.add_resource(ProjectAppsView, '/projects/<string:project_id>/apps', endpoint='project_apps')
 api.add_resource(ProjectCPUView, '/projects/<string:project_id>/metrics/cpu')
 api.add_resource(ProjectMemoryUsageView,'/projects/<string:project_id>/metrics/memory')
+api.add_resource(ProjectNetworkRequestView,'/projects/<string:project_id>/metrics/network')
 
 # User Project routes
 api.add_resource(UserProjectsView, '/users/<string:user_id>/projects')


### PR DESCRIPTION
### What does this PR do?

- It adds an endpoint to access project network request metrics 

- Accessed through `/projects/{project_id}/metrics/network` 