### PR TITLE
feat: fetch single db in project

### DIFF
--- a/api_docs.yml
+++ b/api_docs.yml
@@ -1966,6 +1966,38 @@ paths:
                 500:
                     description: "Internal Server Error"
 
+
+    "/projects/{project_id}/databases/{database_id}":
+        get:
+            tags:
+                - databases
+            consumes:
+                - application/json
+            parameters:
+                - in: header
+                  name: Authorization
+                  required: true
+                  type: string
+                - in: path
+                  name: project_id
+                  required: true
+                  type: string
+                - in: path
+                  name: database_id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                200:
+                    description: "Success"
+                400:
+                    description: "Bad request"
+                404:
+                    description: "Database not found"
+                500:
+                    description: "Internal Server Error"    
+                
     "/databases":
         post:
             tags:
@@ -2031,6 +2063,31 @@ paths:
                 500:
                     description: "Internal Server Error"
 
+        get:
+            tags:
+                - databases
+            consumes:
+                - application/json
+            parameters:
+                - in: header
+                  name: Authorization
+                  required: true
+                  type: string
+                - in: path
+                  name: database_id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                200:
+                    description: "Success"
+                400:
+                    description: "Bad request"
+                404:
+                    description: "Database Not Found"
+                500:
+                    description: "Internal Server Error"
     
     "/apps":
 

--- a/app/controllers/project_database.py
+++ b/app/controllers/project_database.py
@@ -135,6 +135,32 @@ class ProjectDatabaseDetailView(Resource):
         return dict(status='success', message="Database Successfully deleted"), 200
 
 
+    @jwt_required
+    def get(self, project_id, database_id):
+        """
+        """
+        database_schema = ProjectDatabaseSchema()
+
+        project = Project.get_by_id(project_id)
+        if not project:
+            return dict(status='fail', message=f'Project with id {project_id} not found'), 404
+
+        database = ProjectDatabase.get_by_id(database_id)
+
+        if not database:
+            return dict(
+                status="fail",
+                message=f"Database with id {database_id} not found."
+            ), 404
+        
+        database_data, errors = database_schema.dumps(database)
+
+        if errors:
+            return dict(status='fail', message=errors), 500
+
+        return dict(status='success', data=dict(database=json.loads(database_data))), 200
+
+
 class ProjectDatabaseAdminView(Resource):
     @admin_required
     def post(self):
@@ -255,3 +281,25 @@ class ProjectDatabaseAdminDetailView(Resource):
             return dict(status='fail', message=f'Internal Server Error'), 500
 
         return dict(status='success', message="Database Successfully deleted"), 200
+
+
+    @admin_required
+    def get(self, database_id):
+        """
+        """
+        database_schema = ProjectDatabaseSchema()
+
+        database = ProjectDatabase.get_by_id(database_id)
+
+        if not database:
+            return dict(
+                status="fail",
+                message=f"Database with id {database_id} not found."
+            ), 404
+        
+        database_data, errors = database_schema.dumps(database)
+
+        if errors:
+            return dict(status='fail', message=errors), 500
+
+        return dict(status='success', data=dict(database=json.loads(database_data))), 200


### PR DESCRIPTION
### What does this PR do?

   
- Adds endpoints to retrieve a single database in a project

- This can be tested at GET on `/projects/{project_id}/databases/{database_id}`
-  The admin route to get the single database is  GET `/databases/{database_id}`                                             