### PR TITLE
chore: deactivate pv and pvc functionality

### DIFF
--- a/app/controllers/app.py
+++ b/app/controllers/app.py
@@ -150,29 +150,29 @@ class AppsView(Resource):
                     name=app_alias)
 
             # create app deployment's pvc meta and spec
-            pvc_name = f'{app_alias}-pvc'
-            pvc_meta = client.V1ObjectMeta(name=pvc_name)
+            # pvc_name = f'{app_alias}-pvc'
+            # pvc_meta = client.V1ObjectMeta(name=pvc_name)
 
-            access_modes = ['ReadWriteOnce']
-            storage_class = 'openebs-standard'
-            resources = client.V1ResourceRequirements(
-                requests=dict(storage='1Gi'))
+            # access_modes = ['ReadWriteOnce']
+            # storage_class = 'openebs-standard'
+            # resources = client.V1ResourceRequirements(
+            #     requests=dict(storage='1Gi'))
 
-            pvc_spec = client.V1PersistentVolumeClaimSpec(
-                access_modes=access_modes, resources=resources, storage_class_name=storage_class)
+            # pvc_spec = client.V1PersistentVolumeClaimSpec(
+            #     access_modes=access_modes, resources=resources, storage_class_name=storage_class)
 
             # Create a PVC 
-            pvc = client.V1PersistentVolumeClaim(
-                api_version="v1",
-                kind="PersistentVolumeClaim", 
-                metadata=pvc_meta,
-                spec=pvc_spec
-            )
+            # pvc = client.V1PersistentVolumeClaim(
+            #     api_version="v1",
+            #     kind="PersistentVolumeClaim", 
+            #     metadata=pvc_meta,
+            #     spec=pvc_spec
+            # )
 
-            kube_client.kube.create_namespaced_persistent_volume_claim(
-                namespace=namespace,
-                body=pvc
-            )
+            # kube_client.kube.create_namespaced_persistent_volume_claim(
+            #     namespace=namespace,
+            #     body=pvc
+            # )
 
             # create deployment
             dep_name = f'{app_alias}-deployment'
@@ -191,14 +191,14 @@ class AppsView(Resource):
                 image=app_image,
                 ports=[client.V1ContainerPort(container_port=app_port)],
                 env=env,
-                command=command,
-                volume_mounts=[client.V1VolumeMount(mount_path="/data", name=dep_name)]
+                command=command
+                # volume_mounts=[client.V1VolumeMount(mount_path="/data", name=dep_name)]
             )
 
-            volumes = client.V1Volume(
-                name=dep_name,
-                persistent_volume_claim=client.V1PersistentVolumeClaimVolumeSource(claim_name=pvc_name)
-            )
+            # volumes = client.V1Volume(
+            #     name=dep_name,
+            #     persistent_volume_claim=client.V1PersistentVolumeClaimVolumeSource(claim_name=pvc_name)
+            # )
             # spec
             template = client.V1PodTemplateSpec(
                 metadata=client.V1ObjectMeta(labels={
@@ -206,8 +206,8 @@ class AppsView(Resource):
                 }),
                 spec=client.V1PodSpec(
                     containers=[container],
-                    image_pull_secrets=[image_pull_secret],
-                    volumes=[volumes]
+                    image_pull_secrets=[image_pull_secret]
+                    # volumes=[volumes]
                 )
             )
 
@@ -499,24 +499,24 @@ class ProjectAppsView(Resource):
                     name=app_alias)
 
             # create app deployment's pvc meta and spec
-            pvc_name = f'{app_alias}-pvc'
-            pvc_meta = client.V1ObjectMeta(name=pvc_name)
+            # pvc_name = f'{app_alias}-pvc'
+            # pvc_meta = client.V1ObjectMeta(name=pvc_name)
 
-            access_modes = ['ReadWriteOnce']
-            storage_class = 'openebs-standard'
-            resources = client.V1ResourceRequirements(
-                requests=dict(storage='1Gi'))
+            # access_modes = ['ReadWriteOnce']
+            # storage_class = 'openebs-standard'
+            # resources = client.V1ResourceRequirements(
+            #     requests=dict(storage='1Gi'))
 
-            pvc_spec = client.V1PersistentVolumeClaimSpec(
-                access_modes=access_modes, resources=resources, storage_class_name=storage_class)
+            # pvc_spec = client.V1PersistentVolumeClaimSpec(
+            #     access_modes=access_modes, resources=resources, storage_class_name=storage_class)
 
             # Create a PVC 
-            pvc = client.V1PersistentVolumeClaim(
-                api_version="v1",
-                kind="PersistentVolumeClaim", 
-                metadata=pvc_meta,
-                spec=pvc_spec
-            )
+            # pvc = client.V1PersistentVolumeClaim(
+            #     api_version="v1",
+            #     kind="PersistentVolumeClaim", 
+            #     metadata=pvc_meta,
+            #     spec=pvc_spec
+            # )
 
             # kube_client.kube.create_namespaced_persistent_volume_claim(
             #     namespace=namespace,
@@ -546,10 +546,10 @@ class ProjectAppsView(Resource):
             )
 
             #pod volumes 
-            volumes = client.V1Volume(
-                name=dep_name
-                # persistent_volume_claim=client.V1PersistentVolumeClaimVolumeSource(claim_name=pvc_name)
-            )
+            # volumes = client.V1Volume(
+            #     name=dep_name
+            #     # persistent_volume_claim=client.V1PersistentVolumeClaimVolumeSource(claim_name=pvc_name)
+            # )
 
             # spec
             template = client.V1PodTemplateSpec(
@@ -943,18 +943,18 @@ class AppDetailView(Resource):
                 )
 
             #delete pvc 
-            pvc_name = f'{app.alias}-pvc'
+            # pvc_name = f'{app.alias}-pvc'
 
-            pvc = kube_client.kube.read_namespaced_persistent_volume_claim(
-                name=pvc_name,
-                namespace=namespace
-            )
+            # pvc = kube_client.kube.read_namespaced_persistent_volume_claim(
+            #     name=pvc_name,
+            #     namespace=namespace
+            # )
 
-            if pvc:
-                kube_client.kube.delete_namespaced_persistent_volume_claim(
-                    name=pvc_name,
-                    namespace=namespace
-                )
+            # if pvc:
+            #     kube_client.kube.delete_namespaced_persistent_volume_claim(
+            #         name=pvc_name,
+            #         namespace=namespace
+            #     )
 
             # delete the app from the database
             deleted = app.delete()


### PR DESCRIPTION
### What does this PR do?

- It deactivates the PV and PVCs that were being created and mounted to every app deployment

### Why the deactivation

- We really do not need them for every app, they end up stressing the cluster resourceswise.
- They also introduce a point of failure for the deployments when Openebs deployment goes down.