### PR TITLE
fix: db password chars and mysql db users creation on multiple hosts

### DIFF
--- a/app/helpers/database_service.py
+++ b/app/helpers/database_service.py
@@ -9,12 +9,13 @@ from types import SimpleNamespace
 
 
 def generate_db_credentials():
+    punctuation = r"""!#%&()+,-:;<=>?@[]^_{|}~"""
     name = ''.join((secrets.choice(string.ascii_letters)
                     for i in range(24)))
     user = ''.join((secrets.choice(string.ascii_letters)
                     for i in range(16)))
     password = ''.join((secrets.choice(
-        string.ascii_letters + string.digits + string.punctuation) for i in range(32)))
+        string.ascii_letters + string.digits + punctuation) for i in range(32)))
     return SimpleNamespace(
         user=user.lower(),
         name=name.lower(),
@@ -149,7 +150,7 @@ class MysqlDbService(DatabaseService):
             cursor.execute(f"CREATE DATABASE {db_name}")
             if self.create_user(user=user, password=password):
                 cursor.execute(
-                    f"GRANT ALL PRIVILEGES ON {db_name}.* To '{user}'")
+                    f"GRANT ALL PRIVILEGES ON {db_name}.* To '{user}'@'%'")
             return True
         except self.Error as e:
             print(e)
@@ -169,7 +170,7 @@ class MysqlDbService(DatabaseService):
                 return False
             cursor = connection.cursor()
             cursor.execute(
-                f"CREATE USER '{user}' IDENTIFIED BY '{password}' ")
+                f"CREATE USER '{user}'@'%' IDENTIFIED BY '{password}' ")
             return True
         except self.Error as e:
             if e.errno == '1396':


### PR DESCRIPTION
### What does this PR do?

It Fixes the following Mysql issues:

1. Remove unwanted symbols in DB password generated:  `/ \ @ "" ` $` where removed from the symbols domain used when generating passwords for DB users. These would lead to passwords that were misinterpreted by the DB host and thus fail user Auth. (This applies to Postgres as well)

2. Create a user on multiple hosts: previously a user was created on a single host which would fail on a multi-server implementation on production. So now a user will be created on multiple hosts and given permissions to only their DB so that they can easily connect.   

### How can this PR be tested?

- Run the branch locally and create, a number of DBs, then retrieve these DBs and check on the status field, it should be `true` to imply they are able to connect. Also, notice that the generated passwords don't have the removed unwanted symbols.