### PR TITLE
Increase email verification link expiration

### DIFF
--- a/app/helpers/token.py
+++ b/app/helpers/token.py
@@ -8,7 +8,7 @@ def generate_token(email, secret_key, password_salt):
     return serializer.dumps(email, salt=password_salt)
 
 
-def validate_token(token, secret_key, password_salt, expiration=3600):
+def validate_token(token, secret_key, password_salt, expiration=86400):
     serializer = URLSafeTimedSerializer(secret_key)
     try:
         email = serializer.loads(


### PR DESCRIPTION
## Problem
Our email verification links to some of the users are expiring almost immediately. Most likely related to time settings. 

## Solution
As we investigate this further, we are going to increase expiration time from 3600 seconds to 86400 seconds and observe. 
