### PR TITLE
feat: add cluster count stats metadata

### DIFF
--- a/app/controllers/clusters.py
+++ b/app/controllers/clusters.py
@@ -60,8 +60,11 @@ class ClustersView(Resource):
         if errors:
             return dict(status='fail', message='Internal Server Error'), 500
 
+        clusters_data_list = json.loads(validated_cluster_data)
+        cluster_count = len(clusters_data_list)
+
         return dict(status='Success',
-                    data=dict(clusters=json.loads(validated_cluster_data))), 200
+                    data=dict(clusters=json.loads(validated_cluster_data),metadata=dict(cluster_count=cluster_count))), 200
 
 
 class ClusterDetailView(Resource):


### PR DESCRIPTION
# Description

This PR adds cluster count metadata to the `/clusters` route 

## Type of change


- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Trello Ticket ID

https://trello.com/c/rKb7IjKn

## How Can This Be Tested?

Pull this branch locally, navigate to API docs to the route `/clusters` on the `GET`


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules