### PR TITLE
Let Apps and projects get deleted if the cluster doesnot exist

### DIFF
--- a/app/controllers/app.py
+++ b/app/controllers/app.py
@@ -942,7 +942,6 @@ class AppDetailView(Resource):
 
             kube_host = cluster.host
             kube_token = cluster.token
-
             kube_client = create_kube_clients(kube_host, kube_token)
 
             # delete deployment and service for the app
@@ -1132,7 +1131,8 @@ class AppDetailView(Resource):
                         body=service
                     )
             if command:
-                cluster_deployment.spec.template.spec.containers[0].command = command.split()
+                cluster_deployment.spec.template.spec.containers[0].command = command.split(
+                )
 
             if env_vars:
                 env = []
@@ -1268,7 +1268,6 @@ class AppCpuUsageView(Resource):
                 status='fail',
                 message=f'project {project_id} not found'
             ), 404
-
         if not is_owner_or_admin(project, current_user_id, current_user_roles):
             return dict(status='fail', message='unauthorised'), 403
 
@@ -1542,7 +1541,7 @@ class AppStorageUsageView(Resource):
             prom_data = prometheus.query(
                 metric='sum(kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace="' +
                        namespace + '", persistentvolumeclaim=~"' + app_alias + '.*"})'
-                )
+            )
             #  change array values to json
             new_data = json.loads(prom_data)
             values = new_data["data"]

--- a/app/helpers/kube.py
+++ b/app/helpers/kube.py
@@ -33,31 +33,33 @@ def create_kube_clients(kube_host=os.getenv('KUBE_HOST'), kube_token=os.getenv('
 
 def delete_cluster_app(kube_client, namespace, app):
     # delete deployment and service for the app
+
     deployment_name = f'{app.alias}-deployment'
     service_name = f'{app.alias}-service'
-    deployment = kube_client.appsv1_api.read_namespaced_deployment(
-        name=deployment_name,
-        namespace=namespace
-    )
+    try:
 
-    if deployment:
-        kube_client.appsv1_api.delete_namespaced_deployment(
+        deployment = kube_client.appsv1_api.read_namespaced_deployment(
             name=deployment_name,
             namespace=namespace
         )
 
-    service = kube_client.kube.read_namespaced_service(
-        name=service_name,
-        namespace=namespace
-    )
+        if deployment:
+            kube_client.appsv1_api.delete_namespaced_deployment(
+                name=deployment_name,
+                namespace=namespace
+            )
 
-    if service:
-        kube_client.kube.delete_namespaced_service(
+        service = kube_client.kube.read_namespaced_service(
             name=service_name,
             namespace=namespace
         )
 
-    try:
+        if service:
+            kube_client.kube.delete_namespaced_service(
+                name=service_name,
+                namespace=namespace
+            )
+
         secret = kube_client.kube.read_namespaced_secret(
             name=app.alias,
             namespace=namespace
@@ -66,7 +68,7 @@ def delete_cluster_app(kube_client, namespace, app):
             name=app.alias,
             namespace=namespace
         )
-    except  Exception as e:
+    except Exception as e:
         if e.status != 404:
             return dict(status='fail', message=str(e)), 500
 


### PR DESCRIPTION
# Description
Apps and Projects in some instances were not letting a user delete them. This is for the case where the cluster doesn't exist and the cluster host and token point to nowhere.

## How Can This Be Tested?
- Run the branch locally,
- If you have a project and an app on a cluster that doesn't exist try deleting them

