### PR TITLE
Revert from custom domain to cc domain

### DIFF
--- a/api_docs.yml
+++ b/api_docs.yml
@@ -2408,6 +2408,33 @@ paths:
                     description: "Bad request"
                 500:
                     description: "Internal Server Error"
+
+    "/apps/{app_id}/revert_url":
+        get:
+            description: "reverts custom url to CC provided url"
+            tags:
+                - apps
+            consumes:
+                - application/json
+            parameters:
+                - in: header
+                  name: Authorization
+                  required: true
+                  type: string
+                - in: path
+                  name: app_id
+                  required: true
+                  type: string
+
+            responses:
+                200:
+                    description: "Success"
+                404:
+                    description: "App not found"
+                400:
+                    description: "Bad request"
+                500:
+                    description: "Internal Server Error"
              
 
     "/projects/{project_id}/apps/{app_id}/metrics/cpu":

--- a/app/controllers/__init__.py
+++ b/app/controllers/__init__.py
@@ -20,7 +20,8 @@ from .project import (
     ProjectsView, ProjectDetailView, UserProjectsView,
     ProjectCPUView, ProjectMemoryUsageView, ProjectNetworkRequestView, ProjectStorageUsageView)
 from .app import (AppsView, ProjectAppsView, AppDetailView, AppLogsView,
-                  AppCpuUsageView, AppMemoryUsageView, AppNetworkUsageView, AppStorageUsageView, AppDataSummaryView)
+                  AppCpuUsageView, AppMemoryUsageView, AppNetworkUsageView, AppStorageUsageView,
+                  AppDataSummaryView, AppRevertView)
 from .registry import RegistriesView
 from .project_database import (ProjectDatabaseView, ProjectDatabaseDetailView, ProjectDatabaseAdminView,
                                ProjectDatabaseAdminDetailView, ProjectDatabaseResetView, ProjectDatabaseAdminResetView,

--- a/app/controllers/app.py
+++ b/app/controllers/app.py
@@ -1262,12 +1262,6 @@ class AppRevertView(Resource):
 
                 ingress.spec.rules.append(new_ingress_rule)
 
-                kube_client.extension_api.patch_namespaced_ingress(
-                    name=ingress_name,
-                    namespace=namespace,
-                    body=ingress
-                )
-
             # Remove custom domain from ingress list
             for item in routes_list:
                 if item.host == custom_domain:

--- a/app/controllers/app.py
+++ b/app/controllers/app.py
@@ -1238,8 +1238,6 @@ class AppRevertView(Resource):
             ingress = ingress_list[0]
             routes_list = ingress.spec.rules
 
-            print(routes_list)
-
             # Check if app subdomain is present in ingress list
             for item in routes_list:
                 if item.host == app_sub_domain:

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -14,7 +14,8 @@ from app.controllers import (
     AppCpuUsageView, AppNetworkUsageView, ProjectNetworkRequestView, AppLogsView, AppStorageUsageView, ProjectStorageUsageView,
     ProjectDatabaseView, ProjectDatabaseDetailView, ProjectDatabaseAdminView, ProjectDatabaseAdminDetailView,
     ProjectDatabaseResetView, ProjectDatabaseAdminResetView, ProjectDatabasePasswordResetView, ProjectDatabaseAdminPasswordResetView,
-    ProjectDatabaseRetrievePasswordView, ProjectDatabaseAdminRetrievePasswordView, DatabaseStatsView, AppDataSummaryView, UserAdminUpdateView)
+    ProjectDatabaseRetrievePasswordView, ProjectDatabaseAdminRetrievePasswordView, DatabaseStatsView, AppDataSummaryView, 
+    UserAdminUpdateView, AppRevertView)
 
 
 api = Api()
@@ -99,6 +100,7 @@ api.add_resource(UserProjectsView, '/users/<string:user_id>/projects')
 # App routes
 api.add_resource(AppsView, '/apps')
 api.add_resource(AppDetailView, '/apps/<string:app_id>')
+api.add_resource(AppRevertView, '/apps/<string:app_id>/revert_url')
 api.add_resource(
     AppCpuUsageView, '/projects/<string:project_id>/apps/<string:app_id>/metrics/cpu')
 api.add_resource(AppMemoryUsageView,


### PR DESCRIPTION
# Description

- Add functionality to revert from a custom domain to a crane cloud issued domain

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Trello Ticket ID

Please add a link to the Trello ticket for the task.

## How Can This Be Tested?

- Fetch the branch `revert-to-cc-domain, run it and revert an existing custom domain back to a cc domain using the `/apps/app_id/revert_url ` endpoint


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules