### PR TITLE
Add admin custom db route

### DIFF
--- a/api_docs.yml
+++ b/api_docs.yml
@@ -2097,6 +2097,10 @@ paths:
                     properties: 
                         database_flavour_name:
                             type: string  
+                        name:
+                            type: string
+                        project_id:
+                            type: string
             produces:
                 - application/json
             responses:


### PR DESCRIPTION
# Description
Adds admin functionality to create custom database name for a project

## How Can This Be Tested?
create project route on `/databases` while logged in as admin
