### PR TITLE
Fix app update route

### DIFF
--- a/api_docs.yml
+++ b/api_docs.yml
@@ -2709,7 +2709,7 @@ paths:
                 500:
                     description: "Internal Server Error"
 
-    "/apps/{app_id}/custom_domains":
+    "/apps/{app_id}/revert_url":
         patch:
             description: "reverts custom url to CC provided url"
             tags:

--- a/app/controllers/app.py
+++ b/app/controllers/app.py
@@ -1188,7 +1188,6 @@ class AppDetailView(Resource):
             )
 
             # update the app in database
-            validated_update_data['url'] = f'https://{custom_domain}'
             updated_app = App.update(app, **validated_update_data)
 
             if not updated_app:

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -111,7 +111,7 @@ api.add_resource(UserProjectsView, '/users/<string:user_id>/projects')
 # App routes
 api.add_resource(AppsView, '/apps')
 api.add_resource(AppDetailView, '/apps/<string:app_id>')
-api.add_resource(AppRevertView, '/apps/<string:app_id>/custom_domains')
+api.add_resource(AppRevertView, '/apps/<string:app_id>/revert_url')
 api.add_resource(
     AppCpuUsageView, '/projects/<string:project_id>/apps/<string:app_id>/metrics/cpu')
 api.add_resource(AppMemoryUsageView,

--- a/app/schemas/project.py
+++ b/app/schemas/project.py
@@ -23,6 +23,10 @@ class ProjectSchema(Schema):
     project_type = fields.String()
     date_created = fields.Date(dump_only=True)
     age = fields.Method("get_age", dump_only=True)
+    apps_count = fields.Method("get_apps_count", dump_only=True)
 
     def get_age(self, obj):
         return get_item_age(obj.date_created)
+
+    def get_apps_count(self, obj):
+        return len(obj.apps)


### PR DESCRIPTION
# Description
- Fix app update issue
- Change `/custom_domain` route to `/revert_url`
- Add apps count to project response

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Trello Ticket ID

Trello ticket is [here](https://trello.com/c/UKsUn4qn/1058-investigate-fix-app-update-feature-backend)

## How Can This Be Tested?

- Try updating an application
- For failed apps without URLs, try reverting URL with `/revert_url`
