### PR TITLE
Fix revert update issue

### DIFF
--- a/app/controllers/app.py
+++ b/app/controllers/app.py
@@ -1240,7 +1240,9 @@ class AppRevertView(Resource):
                 return dict(status='fail', message='Internal server error'), 500
 
             app_sub_domain = get_app_subdomain(app.alias)
-            custom_domain = app.url.split("//", 1)[-1]
+            custom_domain = None
+            if type(app.url) is str:
+                custom_domain = app.url.split("//", 1)[-1]
 
             if custom_domain == app_sub_domain:
                 return dict(


### PR DESCRIPTION
# Description
When reverting some apps, URLs are Null hence a checker is to be put in to counter this.
Therefore PR adds string checker for app URL on revert app URL route.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Trello Ticket ID
Link to the Trello ticket is [here](https://trello.com/c/OAcTqX1q/1075-test-app-url-reset-route)

## How Can This Be Tested?

Revert url on `apss/revert_url` endpoint
