### PR TITLE
ft: add credits to user object on fetch all users

### DIFF
--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -2,8 +2,7 @@ from marshmallow import Schema, fields, validate, pre_load
 
 from .role import RoleSchema
 from app.helpers.age_utility import get_item_age
-
-
+from .credits import CreditSchema
 class UserSchema(Schema):
 
     id = fields.String(dump_only=True)
@@ -28,6 +27,7 @@ class UserSchema(Schema):
     date_created = fields.Date(dump_only=True)
     age = fields.Method("get_age", dump_only=True)
     is_beta_user = fields.Boolean()
+    credits = fields.Nested(CreditSchema, many=True, dump_only=True)
 
     def get_age(self, obj):
         return get_item_age(obj.date_created)


### PR DESCRIPTION
# Description

Add details on a user's credits when retrieving user list by admin

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Trello Ticket ID

[https://trello.com/c/JsbQ7N4w](https://trello.com/c/JsbQ7N4w)

## How Can This Be Tested?

- Pull branch and run the endpoint GET /users note that the credits object for each user is returned in the user list. If the user has no credit record it will return an empty list for the credit object.

##   Screenshot
<img width="1377" alt="Screenshot 2022-07-20 at 14 07 12" src="https://user-images.githubusercontent.com/36065782/179971437-4fda3c3a-ed12-47a2-a2c7-c13f78427707.png">


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules