### PR TITLE
Add route to get cluster projects 

### DIFF
--- a/api_docs.yml
+++ b/api_docs.yml
@@ -657,34 +657,42 @@ paths:
         500:
           description: "Internal Server Error"
 
-    "/clusters/{cluster_id}/projects":
-      get:
-        tags:
-          - clusters
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        parameters:
-          - in: header
-            name: Authorization
-            required: true
-            description: "Bearer [token]"
-            type: string
-          - in: path
-            name: cluster_id
-            required: true
-            type: string
+  "/clusters/{cluster_id}/projects":
+    get:
+      tags:
+        - clusters
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: header
+          name: Authorization
+          required: true
+          description: "Bearer [token]"
+          type: string
+        - in: path
+          name: cluster_id
+          required: true
+          type: string
+        - in: query
+          name: page
+          type: integer
+          description: Page number
+        - in: query
+          name: per_page
+          type: integer
+          description: Number of items per page
 
-        responses:
-          200:
-            description: "Get projects in a cluster"
-          404:
-            description: "cluster not found"
-          400:
-            description: "Bad request"
-          500:
-            description: "Internal Server Error"
+      responses:
+        200:
+          description: "Get projects in a cluster"
+        404:
+          description: "cluster not found"
+        400:
+          description: "Bad request"
+        500:
+          description: "Internal Server Error"
 
   "/clusters/{cluster_id}/namespaces":
     get:

--- a/api_docs.yml
+++ b/api_docs.yml
@@ -657,6 +657,35 @@ paths:
         500:
           description: "Internal Server Error"
 
+    "/clusters/{cluster_id}/projects":
+      get:
+        tags:
+          - clusters
+        consumes:
+          - application/json
+        produces:
+          - application/json
+        parameters:
+          - in: header
+            name: Authorization
+            required: true
+            description: "Bearer [token]"
+            type: string
+          - in: path
+            name: cluster_id
+            required: true
+            type: string
+
+        responses:
+          200:
+            description: "Get projects in a cluster"
+          404:
+            description: "cluster not found"
+          400:
+            description: "Bad request"
+          500:
+            description: "Internal Server Error"
+
   "/clusters/{cluster_id}/namespaces":
     get:
       tags:

--- a/app/controllers/__init__.py
+++ b/app/controllers/__init__.py
@@ -20,7 +20,7 @@ from .credits import CreditView, CreditDetailView
 from .user_role import UserRolesView
 from .transactions import TransactionRecordView, TransactionRecordDetailView, CreditTransactionRecordView, CreditPurchaseTransactionRecordView
 from .project import (
-    ProjectsView, ProjectDetailView, UserProjectsView, ProjectGetCostsView,
+    ProjectsView, ProjectDetailView, UserProjectsView, ProjectGetCostsView, ClusterProjectsView,
     ProjectCPUView, ProjectMemoryUsageView, ProjectNetworkRequestView, ProjectStorageUsageView)
 from .app import (AppsView, ProjectAppsView, AppDetailView, AppLogsView,
                   AppCpuUsageView, AppMemoryUsageView, AppNetworkUsageView, AppStorageUsageView,

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -14,10 +14,10 @@ from app.controllers import (
     AppCpuUsageView, AppNetworkUsageView, ProjectNetworkRequestView, AppLogsView, AppStorageUsageView, ProjectStorageUsageView,
     ProjectDatabaseView, ProjectDatabaseDetailView, ProjectDatabaseAdminView, ProjectDatabaseAdminDetailView,
     ProjectDatabaseResetView, ProjectDatabaseAdminResetView, ProjectDatabasePasswordResetView, ProjectDatabaseAdminPasswordResetView,
-    ProjectDatabaseRetrievePasswordView, ProjectDatabaseAdminRetrievePasswordView, DatabaseStatsView, AppDataSummaryView, 
+    ProjectDatabaseRetrievePasswordView, ProjectDatabaseAdminRetrievePasswordView, DatabaseStatsView, AppDataSummaryView,
     ProjectDatabaseRetrievePasswordView, ProjectDatabaseAdminRetrievePasswordView, DatabaseStatsView, AppDataSummaryView,
     UserAdminUpdateView, AppRevertView, ProjectGetCostsView, TransactionRecordView, CreditTransactionRecordView, CreditPurchaseTransactionRecordView, BillingInvoiceView, BillingInvoiceNotificationView,
-    SystemStatusView, CreditDetailView, ProjectUsersView, ProjectUsersTransferView, AppReviseView, ProjectUsersHandleInviteView)
+    SystemStatusView, CreditDetailView, ProjectUsersView, ProjectUsersTransferView, AppReviseView, ProjectUsersHandleInviteView, ClusterProjectsView)
 from app.controllers.billing_invoice import BillingInvoiceDetailView
 from app.controllers.receipts import BillingReceiptsDetailView, BillingReceiptsView
 from app.controllers.transactions import TransactionRecordDetailView, TransactionVerificationView
@@ -79,6 +79,8 @@ api.add_resource(ClusterStorageClassView,
                  '/clusters/<string:cluster_id>/storage_classes')
 api.add_resource(ClusterStorageClassDetailView,
                  '/clusters/<string:cluster_id>/storage_classes/<string:storage_class_name>')
+api.add_resource(ClusterProjectsView,
+                 '/clusters/<string:cluster_id>/projects')
 
 # Credit routes
 api.add_resource(CreditView, '/credit', endpoint='credit')
@@ -105,15 +107,15 @@ api.add_resource(TransactionRecordView,
 api.add_resource(TransactionRecordDetailView,
                  '/projects/<string:project_id>/transactions/<string:record_id>')
 api.add_resource(TransactionVerificationView,
-                  '/projects/<string:project_id>/transactions/<string:transaction_id>/<string:tx_ref>')
+                 '/projects/<string:project_id>/transactions/<string:transaction_id>/<string:tx_ref>')
 
-#Credit Transaction route
+# Credit Transaction route
 api.add_resource(CreditTransactionRecordView,
-                 '/projects/<string:project_id>/credit_transactions', endpoint='credit_transactions') 
+                 '/projects/<string:project_id>/credit_transactions', endpoint='credit_transactions')
 
-#Credit Purchase Transaction route
+# Credit Purchase Transaction route
 api.add_resource(CreditPurchaseTransactionRecordView,
-                 '/projects/<string:project_id>/credit_purchase_transactions', endpoint='credit_purchase_transactions')             
+                 '/projects/<string:project_id>/credit_purchase_transactions', endpoint='credit_purchase_transactions')
 
 # Invoice routes
 api.add_resource(BillingInvoiceView,
@@ -150,7 +152,8 @@ api.add_resource(UserProjectsView, '/users/<string:user_id>/projects')
 api.add_resource(AppsView, '/apps')
 api.add_resource(AppDetailView, '/apps/<string:app_id>')
 api.add_resource(AppRevertView, '/apps/<string:app_id>/revert_url')
-api.add_resource(AppReviseView, '/apps/<string:app_id>/revise/<string:revision_id>')
+api.add_resource(
+    AppReviseView, '/apps/<string:app_id>/revise/<string:revision_id>')
 api.add_resource(
     AppCpuUsageView, '/projects/<string:project_id>/apps/<string:app_id>/metrics/cpu')
 api.add_resource(AppMemoryUsageView,
@@ -190,7 +193,9 @@ api.add_resource(DatabaseStatsView, '/databases/stats')
 
 # Project Users
 api.add_resource(ProjectUsersView, '/projects/<string:project_id>/users')
-api.add_resource(ProjectUsersTransferView, '/projects/<string:project_id>/users/transfer')
-api.add_resource(ProjectUsersHandleInviteView, '/projects/<string:project_id>/users/handle_invite')
+api.add_resource(ProjectUsersTransferView,
+                 '/projects/<string:project_id>/users/transfer')
+api.add_resource(ProjectUsersHandleInviteView,
+                 '/projects/<string:project_id>/users/handle_invite')
 # system status
 api.add_resource(SystemStatusView, '/system_status')


### PR DESCRIPTION
# Description
Add an endpoint **GET** `/clusters/{cluster_id}/projects` to return projects in the cluster

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Can This Be Tested?
Run application and got to **GET** `/clusters/{cluster_id}/projects` or through the API docs


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules