### PR TITLE
getting projects now return admin_disabled field

### DIFF
--- a/app/schemas/project.py
+++ b/app/schemas/project.py
@@ -26,6 +26,7 @@ class ProjectSchema(Schema):
     age = fields.Method("get_age", dump_only=True)
     apps_count = fields.Method("get_apps_count", dump_only=True)
     disabled = fields.Boolean()
+    admin_disabled = fields.Boolean()
 
 
     def get_age(self, obj):


### PR DESCRIPTION
# Description

Project GET endpoint requests should return the admin_disabled fields for projects

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


## Trello Ticket ID

https://trello.com/c/UpqXuoQV/1466-fix-admindisabled

## How Can This Be Tested?

Request projects from projects [GET] endpoint, and admin_disabled field should bee seen for the projects


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules