### PR TITLE
Implemented search feature for projects in the backend

### DIFF
--- a/api_docs.yml
+++ b/api_docs.yml
@@ -2171,6 +2171,10 @@ paths:
           description: "Bearer [token]"
           type: string
         - in: query
+          name: keywords
+          type: string
+          description: Enter keywords if searching 
+        - in: query
           name: page
           type: integer
           description: Page number


### PR DESCRIPTION
# Description
Implementing the search feature for projects in the backend to avoid the issues that arise due to pagination  about searching for projects on the frontend  

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Trello Ticket ID

https://trello.com/c/dRkBeYAD/1471-implementing-the-search-capability-in-the-backend-for-various-endpoints

## How Can This Be Tested?

Just add the "keywords" parameter and the respective searched text in the URL for the GET endpoint of projects to activate the search feature .

Example to get all projects with 'test' keyword in them : `/projects?keywords=test&page=1&per_page=10`

For normal workflow getting all projects without any search criteria : `/projects?page=1&per_page=10`

**NB: All usecases are paginated**

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules