### PR TITLE
feat: Add support for viewing inactive users per specific date.

### DIFF
--- a/api_docs.yml
+++ b/api_docs.yml
@@ -496,6 +496,41 @@ paths:
         500:
           description: "Internal Server Error"
 
+  "/users/inactive_users":
+    get:
+      tags:
+        - users
+      consumes:
+        - application/json
+      parameters:
+        - in: header
+          name: Authorization
+          required: true
+          description: "Bearer [token]"
+        - in: query
+          name: date
+          required: true
+          type: string
+          format: date
+          description: day since last login
+        - in: query
+          name: page
+          type: integer
+          description: Page number
+        - in: query
+          name: per_page
+          type: integer
+          description: Number of items per page
+      produces:
+        - application/json
+      responses:
+        200:
+          description: "Success"
+        400:
+          description: "Bad request"
+        500:
+          description: "Internal Server Error"
+
   "/clusters":
     post:
       tags:

--- a/app/controllers/__init__.py
+++ b/app/controllers/__init__.py
@@ -4,7 +4,7 @@ from .index import IndexView
 from .users import (
     UsersView, UserLoginView, UserEmailVerificationView,
     EmailVerificationRequest, ForgotPasswordView, ResetPasswordView,
-    UserDetailView, AdminLoginView, OAuthView, UserDataSummaryView, UserAdminUpdateView, UserActivitesView)
+    UserDetailView, AdminLoginView, OAuthView, UserDataSummaryView, UserAdminUpdateView, UserActivitesView, InActiveUsersView)
 from .deployments import DeploymentsView
 from .clusters import (
     ClustersView, ClusterDetailView, ClusterNamespacesView,

--- a/app/controllers/users.py
+++ b/app/controllers/users.py
@@ -899,7 +899,6 @@ class UserActivitesView(Resource):
 class InActiveUsersView(Resource):
     computed_results = {}  # Dictionary to cache computed results
     
-    @admin_required
     def get(self):
         user_schema = UserSchema(many=True)
         page = request.args.get('page', 1,type=int)
@@ -948,12 +947,8 @@ class InActiveUsersView(Resource):
             'next': paginated.next_num,
             'prev': paginated.prev_num
         }
-
-            users_data, errors = user_schema.dumps(users)
-            users_data, errors = user_schema.dumps(users)
-            self.computed_results[days_difference] = users_data
+        
         users_data, errors = user_schema.dumps(users)
-            self.computed_results[days_difference] = users_data
 
         if errors:
             return dict(status='fail', message=errors), 400

--- a/app/controllers/users.py
+++ b/app/controllers/users.py
@@ -899,6 +899,7 @@ class UserActivitesView(Resource):
 class InActiveUsersView(Resource):
     computed_results = {}  # Dictionary to cache computed results
     
+    @admin_required
     def get(self):
         user_schema = UserSchema(many=True)
         page = request.args.get('page', 1,type=int)

--- a/app/controllers/users.py
+++ b/app/controllers/users.py
@@ -904,27 +904,21 @@ class InActiveUsersView(Resource):
         user_schema = UserSchema(many=True)
         page = request.args.get('page', 1,type=int)
         per_page = request.args.get('per_page', 10, type=int)
-        entered_date = request.args.get("date")
-        days = request.args.get("days", 0, type=int)
-        weeks = request.args.get("weeks", 0, type=int)
-        months = request.args.get("months", 0, type=int)
-        years = request.args.get("years", 0, type=int)
-        today = datetime.now().date()
+        from_entered_date = request.args.get("from_date")
+        to_entered_date = request.args.get("to_date")
 
-        if (entered_date is not None):
+        if (from_entered_date is not None and to_entered_date is not None):
             try:
-                entered_date = datetime.strptime(entered_date, "%Y-%m-%d").date()  # Standardize the date format
+                from_entered_date = datetime.strptime(entered_date, "%Y-%m-%d").date()  # Standardize the date format
+                to_entered_date = datetime.strptime(entered_date, "%Y-%m-%d").date()  # Standardize the date format
             except ValueError:
-                return dict(status='fail', message="Invalid date format"), 400
-        elif any([days, weeks, months, years]):
-            entered_date = today - timedelta(days=days, weeks=weeks, months=months, years=years)
         else:
             return dict(status='fail', message="Missing required parameters"), 400
         
-        if entered_date >= today:
+        if to_entered_date >= today:
                 return dict(status='fail', message="Entered date cannot be in the future"), 400
 
-        time_difference = relativedelta(today, entered_date)
+        time_difference = relativedelta(to_entered_date, from_entered_date)
         days_difference = time_difference.days
 
         if days_difference in self.computed_results:

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,6 +1,6 @@
 from flask_restful import Api
 from app.controllers import (
-    IndexView, UsersView, UserLoginView, OAuthView, DeploymentsView, RolesView,
+    IndexView, UsersView, UserLoginView, OAuthView, DeploymentsView, RolesView, InActiveUsersView,
     RolesDetailView, CreditAssignmentView, CreditAssignmentDetailView,  CreditView, UserRolesView, UserDataSummaryView, ClustersView,
     ClusterDetailView, ClusterNamespacesView,
     ClusterNamespaceDetailView, ClusterNodesView, ClusterNodeDetailView,
@@ -22,7 +22,6 @@ from app.controllers.billing_invoice import BillingInvoiceDetailView
 from app.controllers.receipts import BillingReceiptsDetailView, BillingReceiptsView
 from app.controllers.transactions import TransactionRecordDetailView, TransactionVerificationView
 
-
 api = Api()
 
 # Index route
@@ -41,6 +40,7 @@ api.add_resource(OAuthView, '/users/oauth')
 api.add_resource(UserDataSummaryView, '/users/summary')
 api.add_resource(UserAdminUpdateView, '/users/admin_update')
 api.add_resource(UserActivitesView, '/users/activities')
+api.add_resource(InActiveUsersView, '/users/inactive_users', endpoint='inactive_users')
 
 
 # Deployments


### PR DESCRIPTION
# Description
Since logic for supporting last-seen is already in existed, inactive users is built on top of it in a way that if a user has. not logged in to the platform since the specified date, they will be added to a list of inactive users and then returned.

The logic caches results per date so that the next time the same date is entered, the saved cache is returned.

with bigger databases, if this slow we shall spawn a background thread to recompute for new dates there by reducing lots of execution time

cc @MutegekiHenry @neelxie

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## Trello Ticket ID

Please add a link to the Trello ticket for the task.

## How Can This Be Tested?

Pull down the changes 
- `git cherry-pick`
- run the server
- execute `http://127.0.0.1:5000/users/inactive_users?date=2000-12-05` using postman


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules