### PR TITLE
update query parameters for inactive user's endpoint

### DIFF
--- a/api_docs.yml
+++ b/api_docs.yml
@@ -511,11 +511,17 @@ paths:
           required: true
           description: "Bearer [token]"
         - in: query
-          name: date
+          name: start
           required: true
           type: string
           format: date
-          description: day since last login
+          description: start date for last login
+        - in: query
+          name: end
+          required: true
+          type: string
+          format: date
+          description: end date for last login
         - in: query
           name: page
           type: integer


### PR DESCRIPTION
# Description

added the start and end date query parameter for `"/users/inactive_users":`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Trello Ticket ID


## How Can This Be Tested?

navigate to `http://127.0.0.1:5000/apidocs/#/users/get_users_inactive_users`


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules