### PR TITLE
Adding a default to user creation

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -33,7 +33,7 @@ class User(ModelMixin):
     credits = db.relationship('Credit', backref='user', lazy=True)
     credit_assignments = db.relationship('CreditAssignment', backref='user', lazy=True)
 
-    def __init__(self, email, name, password, organisation):
+    def __init__(self, email, name, password, organisation = None):
         """ initialize with email, username and password """
         self.email = email
         self.name = name


### PR DESCRIPTION
# Description

Its a hot fix for suppressing the organisation field at sign up

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Can This Be Tested?
Create a user without supplying the organisation field

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules