### PR TITLE
Refactor the get users endpoint to also fetch respective projects and apps 

### DIFF
--- a/api_docs.yml
+++ b/api_docs.yml
@@ -52,6 +52,10 @@ paths:
           type: string
           description: Enter keywords if searching
         - in: query
+          name: entire_profile
+          type: string
+          description: Enter True if whole profile is to be fetched
+        - in: query
           name: page
           type: integer
           description: Page number


### PR DESCRIPTION

# Description

This is to add extra information to an account's profile when being fetched through adding their respective projects and apps

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Trello Ticket ID

https://trello.com/c/wCa2h1sh/1557-user-profile-endpoint-add-missing-data

## How Can This Be Tested?
Supplying the entire_profile parameter to the Get users endpoint 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules