### PR TITLE
Fixing the GET users endpoint and projects_count to the user-profile information

### DIFF
--- a/api_docs.yml
+++ b/api_docs.yml
@@ -52,10 +52,6 @@ paths:
           type: string
           description: Enter keywords if searching
         - in: query
-          name: entire_profile
-          type: string
-          description: Enter True if whole profile is to be fetched
-        - in: query
           name: page
           type: integer
           description: Page number


### PR DESCRIPTION

# Description

Fixing the GET users endpoint and adding projects_count to the user-profile information

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## How Can This Be Tested?

Through fetching the extra user info , by default the projects count will be returned

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules