### PR TITLE
Fixing the resend of email to collaborators through refactoring the invitation endpoint.

### DIFF
--- a/api_docs.yml
+++ b/api_docs.yml
@@ -3103,6 +3103,8 @@ paths:
                 type: string
               role:
                 type: string
+              resend:
+                type: string
       produces:
         - application/json
       responses:


### PR DESCRIPTION

# Description

This is to cater for the provision of resending the collaboration email incase someone doesnt receive it or is not able to find it in anyway.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Trello Ticket ID

https://trello.com/c/ExIO27Jh/1582-endpoint-to-resend-invite-for-project-collaboration

## How Can This Be Tested?

This can be tested through re using the same endpoint for sending collaboration email with the `resend` option either set to True or False depending on the circumstances.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules