### PR TITLE
make resend field optional on adding user to project

### DIFF
--- a/app/controllers/project_users.py
+++ b/app/controllers/project_users.py
@@ -26,9 +26,8 @@ class ProjectUsersView(Resource):
         project_user_schema = ProjectUserSchema()
 
         invitation_data = request.get_json()
-        resend_invite = (invitation_data).get('resend' , False)
-
-        del invitation_data['resend']
+        resend_invite = invitation_data.pop('resend', False)
+        
 
         project_user_data = invitation_data
 


### PR DESCRIPTION
# Description
Makes resend field optional and prevents app from crashing when trying to add and anonymous user

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Trello Ticket ID
[link here](https://trello.com/c/rfE9bdyy/1741-make-resend-field-optional-on-post-projects-projectid-users)

## How Can This Be Tested?
try inviting a user without adding a resend field on post request of `/projects/project_id/users`


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules