### PR TITLE
chore: add pagination to user activities and application revisions

### DIFF
--- a/api_docs.yml
+++ b/api_docs.yml
@@ -472,6 +472,14 @@ paths:
           required: true
           description: "Bearer [token]"
         - in: query
+          name: page
+          type: integer
+          description: Page number
+        - in: query
+          name: per_page
+          type: integer
+          description: Number of items per page
+        - in: query
           name: operation
           required: false
           type: string

--- a/api_docs.yml
+++ b/api_docs.yml
@@ -3776,6 +3776,14 @@ paths:
           name: app_id
           required: true
           type: string
+        - in: query
+          name: page
+          type: integer
+          description: Page number for revisions
+        - in: query
+          name: per_page
+          type: integer
+          description: Number of revisions per page
 
       responses:
         200:

--- a/app/controllers/users.py
+++ b/app/controllers/users.py
@@ -14,6 +14,7 @@ from app.helpers.confirmation import send_verification
 from app.helpers.email import send_email
 from app.helpers.token import validate_token
 from app.helpers.decorators import admin_required
+from app.helpers.pagination import paginate
 import requests
 import secrets
 import string
@@ -1017,12 +1018,14 @@ class UserActivitesView(Resource):
             # get logs
             activities = mongo.db['activities'].find(validated_data_query)
             json_data = dumps(activities)
-
-            # TODO: Add pagination for these activities
+            
+            # Add pagination for these activities
+            pagination_meta_data , paginated_items = paginate(json.loads(json_data), 10, 1)
+            print(pagination_meta_data , paginated_items)
 
             return dict(
                 status='success',
-                data=dict(activity=json.loads(json_data))
+                data=dict(pagination = pagination_meta_data , activity=paginated_items)
             ), 200
         except Exception as err:
             return dict(status='fail', message=str(err)), 400

--- a/app/controllers/users.py
+++ b/app/controllers/users.py
@@ -941,6 +941,10 @@ class UserActivitesView(Resource):
             # get query params
             query_params = request.args
 
+            # get pagination params
+            page = request.args.get('page', 1, type=int)
+            per_page = request.args.get('per_page', 10, type=int)
+
             validated_data_query, errors = activity_schema.load(query_params)
 
             if errors:
@@ -1018,10 +1022,9 @@ class UserActivitesView(Resource):
             # get logs
             activities = mongo.db['activities'].find(validated_data_query)
             json_data = dumps(activities)
-            
+
             # Add pagination for these activities
-            pagination_meta_data , paginated_items = paginate(json.loads(json_data), 10, 1)
-            print(pagination_meta_data , paginated_items)
+            pagination_meta_data , paginated_items = paginate(json.loads(json_data), per_page=per_page, page=page)  
 
             return dict(
                 status='success',


### PR DESCRIPTION
# Description

- This PR adds pagination to the endpoint that returns user activities/logs 
- Application revisions that are returned for an applications can also be many and have been paginated as well

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Trello Ticket ID

https://trello.com/c/JkHXEkz5

## How Can This Be Tested?

- Run this branch locally and visit the `users/activities` endpoint and incase your number of logs exceeds 10, the response data should be paginated as expected.
- To verify that application revisions are paginated as well, checkout this endpoint - `apps/{app_id}` that returns a single application

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules