### PR TITLE
Ch: prevent un authenticated cluster from returning a 401

### DIFF
--- a/app/controllers/app.py
+++ b/app/controllers/app.py
@@ -18,7 +18,7 @@ from app.schemas import AppSchema, MetricsSchema, PodsLogsSchema, AppGraphSchema
 from app.helpers.admin import is_admin, is_authorised_project_user, is_owner_or_admin
 from app.helpers.decorators import admin_required
 from app.helpers.decorators import admin_required
-from app.helpers.kube import create_kube_clients, delete_cluster_app, deploy_user_app
+from app.helpers.kube import create_kube_clients, delete_cluster_app, deploy_user_app, check_kube_error_code
 from app.helpers.url import get_app_subdomain
 from app.models.app import App
 from app.models.user import User
@@ -358,7 +358,7 @@ class ProjectAppsView(Resource):
                         data=dict(pagination=pagination, apps=apps_data_list)), 200
 
         except client.rest.ApiException as exc:
-            return dict(status='fail', message=exc.reason), exc.status
+            return dict(status='fail', message=exc.reason), check_kube_error_code(exc.status)
 
         except Exception as exc:
             return dict(status='fail', message=str(exc)), 500
@@ -490,7 +490,7 @@ class AppDetailView(Resource):
             if exc.status == 404:
                 return dict(status='fail', data=json.loads(app_data), message="Application does not exist on the cluster"), 404
 
-            return dict(status='fail', message=exc.reason), exc.status
+            return dict(status='fail', message=exc.reason), check_kube_error_code(exc.status)
 
         except Exception as exc:
             return dict(status='fail', message=str(exc)), 500
@@ -807,7 +807,7 @@ class AppDetailView(Resource):
                          a_project_id=project.id,
                          a_cluster_id=project.cluster_id,
                          a_app_id=app_id)
-            return dict(status='fail', message=exc.reason), exc.status
+            return dict(status='fail', message=exc.reason), check_kube_error_code(exc.status)
 
         except Exception as exc:
             log_activity('App', status='Failed',
@@ -917,7 +917,7 @@ class AppRevisionsView(Resource):
             if exc.status == 404:
                 return dict(status='fail', data=json.loads(app_data), message="Application does not exist on the cluster"), 404
 
-            return dict(status='fail', message=exc.reason), exc.status
+            return dict(status='fail', message=exc.reason), check_kube_error_code(exc.status)
 
         except Exception as exc:
             return dict(status='fail', message=str(exc)), 500
@@ -1048,7 +1048,7 @@ class AppRevertView(Resource):
             ), 200
 
         except client.rest.ApiException as exc:
-            return dict(status='fail', message=exc.reason), exc.status
+            return dict(status='fail', message=exc.reason), check_kube_error_code(exc.status)
 
         except Exception as exc:
             return dict(status='fail', message=str(exc)), 500
@@ -1176,7 +1176,7 @@ class AppReviseView(Resource):
                          a_project_id=project.id,
                          a_cluster_id=project.cluster_id,
                          a_app_id=app_id)
-            return dict(status='fail', message=exc.reason), exc.status
+            return dict(status='fail', message=exc.reason), check_kube_error_code(exc.status)
 
         except Exception as exc:
             log_activity('App', status='Failed',

--- a/app/controllers/project.py
+++ b/app/controllers/project.py
@@ -7,7 +7,7 @@ from app.helpers.alias import create_alias
 from app.helpers.admin import is_authorised_project_user, is_owner_or_admin, is_current_or_admin, is_admin
 from app.helpers.role_search import has_role
 from app.helpers.activity_logger import log_activity
-from app.helpers.kube import create_kube_clients, delete_cluster_app, disable_project, disable_user_app, enable_project, enable_user_app
+from app.helpers.kube import create_kube_clients, delete_cluster_app, disable_project, disable_user_app, enable_project, enable_user_app, check_kube_error_code
 from app.models.billing_invoice import BillingInvoice
 from app.models.project_users import ProjectUser
 from app.models.user import User
@@ -189,7 +189,7 @@ class ProjectsView(Resource):
                          operation='Create',
                          description=e.body,
                          a_cluster_id=cluster_id)
-            return dict(status='fail', message=str(e.body)), e.status
+            return dict(status='fail', message=str(e.body)), check_kube_error_code(e.status)
 
         except Exception as err:
             log_activity('Project', status='Failed',
@@ -544,7 +544,7 @@ class ProjectDetailView(Resource):
                          description=e.reason,
                          a_project_id=project_id,
                          a_cluster_id=project.cluster_id)
-            return dict(status='fail', message=e.reason), e.status
+            return dict(status='fail', message=e.reason), check_kube_error_code(e.status)
 
         except Exception as e:
             log_activity('Project', status='Failed',

--- a/app/helpers/kube.py
+++ b/app/helpers/kube.py
@@ -261,7 +261,7 @@ def deploy_user_app(kube_client, project: Project, user: User, app: App = None, 
                 service_name, project.alias)
         except:
             pass
-        
+
         kube_client.kube.create_namespaced_service(
             namespace=namespace,
             body=service,
@@ -761,7 +761,7 @@ def enable_project(project: Project):
                              a_cluster_id=project.cluster_id)
                 return SimpleNamespace(
                     message=str(e.body),
-                    status_code=e.status
+                    status_code=check_kube_error_code(e.status)
                 )
 
         # save project
@@ -870,3 +870,8 @@ def sort_apps_for_deployment(apps_data, project, kube_client, user, app_schema):
         apps_data=results,
         failed_apps_data=failed_apps_data
     )
+
+
+def check_kube_error_code(error):
+    # prevent a 401 from being sent to the frontend
+    return 511 if error == 401 else error


### PR DESCRIPTION
# Description

This PR is to prevent the backend from returning a 401 error  when the cluster connection is not authenticated

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Trello Ticket ID

https://trello.com/c/lPXN0HFS

## How Can This Be Tested?

1. Run this branch
2. update your cluster token to the wrong one locally (add a new one if you don't have a token, use the right token when adding and then update to a wrong token.
3. Try out any of the endpoints edited in the code changes, a simple one would be creating a project, The cluster should return a 401 but the endpoint should return 511 in this place


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules