### PR TITLE
chore: limit number of replicas to 3 for a single deployment

### DIFF
--- a/app/schemas/app.py
+++ b/app/schemas/app.py
@@ -36,7 +36,7 @@ class AppSchema(Schema):
     custom_domain = fields.String(validate=validate.Regexp(
         regex=r'^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$',
         error='custom domain should be a valid domain, no protocal required'))
-    replicas = fields.Int(validate=validate.Range(min=1, max=4))
+    replicas = fields.Int(validate=validate.Range(min=1, max=3))
     date_created = fields.Date(dump_only=True)
     age = fields.Method("get_age", dump_only=True)
     has_custom_domain = fields.Boolean()

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ billiard==3.6.4.0
 blinker==1.4
 cached-property==1.5.2
 cachetools==3.1.1
-celery==5.1.2
+celery==5.2.7
 certifi==2023.7.22
 cffi
 chardet==3.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ billiard==3.6.4.0
 blinker==1.4
 cached-property==1.5.2
 cachetools==3.1.1
-celery
+celery==5.1.2
 certifi==2023.7.22
 cffi
 chardet==3.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ billiard==3.6.4.0
 blinker==1.4
 cached-property==1.5.2
 cachetools==3.1.1
-celery==5.2.7
+celery
 certifi==2023.7.22
 cffi
 chardet==3.0.4


### PR DESCRIPTION
# Description

- The goal of this PR is to ensure a threshold of 3 replicas for each deployment made from the backend API.

## Type of change

- [x] This change requires a documentation update

## ClickUp Ticket ID

https://app.clickup.com/t/86967t5g2

## How Can This Be Tested?

- Checkout this branch and on the route for `/projects/{project_id}/apps`, try to make a deployment with more than 3 replicas to notice the error returned if threshold is surpassed. 
