### PR TITLE
modified  the get projects endpoint  added  an option to  retrieve graph data

### DIFF
--- a/api_docs.yml
+++ b/api_docs.yml
@@ -2462,6 +2462,24 @@ paths:
           name: project_type
           type: string
           description: Shows the type of project. Corresponds to the predifined types like Research, Student, Personal, Commercial or Other.
+
+          name: series
+          type: boolean
+          description: Returns graph data when set to true
+        - in: query
+          name: start
+          type: string
+          description: Start date format (YYYY-MM-DD)
+        - in: query
+          name: end
+          type: string
+          description: End date format (YYYY-MM-DD)
+        - in: query
+          name: set_by
+          type: string
+          description: Either month or year
+
+
       responses:
         200:
           description: "Success"
@@ -3745,6 +3763,8 @@ paths:
           name: keywords
           type: string
           description: Enter keywords if searching
+
+          
       responses:
         200:
           description: "Success"

--- a/app/controllers/project.py
+++ b/app/controllers/project.py
@@ -18,7 +18,7 @@ import datetime
 from flask_restful import Resource, request
 from kubernetes import client
 from flask_jwt_extended import jwt_required, get_jwt_identity, get_jwt_claims
-from app.schemas.monitoring_metrics import BillingMetricsSchema
+from app.schemas.monitoring_metrics import BillingMetricsSchema, ProjectGraphSchema
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy import or_, func
 from app.helpers.crane_app_logger import logger
@@ -201,7 +201,6 @@ class ProjectsView(Resource):
     def get(self):
         """
         """
-
         current_user_id = get_jwt_identity()
         current_user_roles = get_jwt_claims()['roles']
         page = request.args.get('page', 1, type=int)
@@ -209,6 +208,13 @@ class ProjectsView(Resource):
         keywords = request.args.get('keywords', '')
         disabled = request.args.get('disabled')
         project_type = request.args.get('project_type')
+
+        graph_filter_data = {
+            'start': request.args.get('start', '2018-01-01'),
+            'end': request.args.get('end', datetime.datetime.now().strftime('%Y-%m-%d')),
+            'set_by': request.args.get('set_by', 'month')
+        }
+        series = request.args.get('series', 'false').lower() == 'true'
 
         project_schema = ProjectSchema(many=True)
         projects = []
@@ -317,12 +323,37 @@ class ProjectsView(Resource):
         user.save()
         # ADD a logger for when user.save does not work
 
-        return dict(status='success',
-                    data=dict(
-                        metadata=project_metadata,
-                        pagination=pagination_data,
-                        projects=json.loads(project_data))), 200
+         # If series is requested, include graph data based on filtered dates
+        if series:
+            validated_query_data, errors = ProjectGraphSchema().load(graph_filter_data)
+            if errors:
+                return dict(status='fail', message=errors), 400
 
+            start = validated_query_data['start']
+            end = validated_query_data['end']
+            set_by = validated_query_data['set_by']
+
+            # Get graph data from Project model
+            graph_data = Project.graph_data(start=start, end=end, set_by=set_by)
+
+            return dict(
+                status='success',
+                data=dict(
+                    metadata=project_metadata,
+                    pagination=pagination_data,
+                    # projects=json.loads(project_data),
+                    graph_data=graph_data
+                )
+            ), 200
+
+        return dict(
+            status='success',
+            data=dict(
+                metadata=project_metadata,
+                pagination=pagination_data,
+                projects=json.loads(project_data)
+            )
+        ), 200
 
 class ProjectDetailView(Resource):
 

--- a/app/schemas/monitoring_metrics.py
+++ b/app/schemas/monitoring_metrics.py
@@ -33,3 +33,16 @@ class BillingMetricsSchema(Schema):
                        error='show from a certain period either pass "lastmonth" or "lastweek"'
                        ),
     ])
+
+
+class ProjectGraphSchema(Schema):
+    start = fields.Date()
+    end = fields.Date()
+    set_by = fields.String(
+        validate=[
+            validate.OneOf(
+                ["year", "month"],
+                error='set_by should be "year" or "month"'
+            ),
+        ]
+    )


### PR DESCRIPTION
This PR enhances the get projects endpoint by adding an option to retrieve graph data. By specifying series=true in the request, an admin can obtain project data in a series format, enabling more advanced data visualization and analysis capabilities.

Type of Change
Added functionality for graph data retrieval through the get projects endpoint.

How Can This Be Tested?
Run the get projects endpoint with series=true parameter to activate graph data retrieval.
Confirm that the data is returned in the expected series format for graphical representation.
Test other project data retrieval requests to ensure this addition does not impact existing functionality