### PR TITLE
Add functionality to query notebook apps and count them in the get apps endpoint

### DIFF
--- a/api_docs.yml
+++ b/api_docs.yml
@@ -3204,6 +3204,10 @@ paths:
           type: boolean
           description: Returns disabled applications
         - in: query
+          name: is_notebook
+          type: boolean
+          description: Returns applications with is_notebook set to true
+        - in: query
           name: active
           type: boolean
           description: Returns active applications

--- a/app/controllers/app.py
+++ b/app/controllers/app.py
@@ -129,6 +129,7 @@ class AppsView(Resource):
         per_page = request.args.get('per_page', 10, type=int)
         series = request.args.get('series', False)
         disabled = request.args.get('disabled', None)
+        is_notebook = request.args.get('is_notebook', None)
 
         if isinstance(series, str):
             series = series.lower() == 'true'
@@ -139,6 +140,7 @@ class AppsView(Resource):
         # since it is a one to one
         metadata = {
             'disabled': App.query.filter_by(disabled=True).count(),
+            'is_notebook': App.query.filter_by(is_notebook=True).count(),
             'total_apps': App.query.count(),
             'failing_apps': AppState.query.filter_by(status="failed").count(),
             'running_apps': AppState.query.filter_by(status="running").count(),
@@ -148,6 +150,9 @@ class AppsView(Resource):
             query = App.query
             if disabled is not None:
                 query = query.filter_by(disabled=disabled)
+
+            if is_notebook is not None:
+                query = query.filter_by(is_notebook=is_notebook)
 
             paginated_apps = query.paginate(
                 page=page, per_page=per_page, error_out=False)


### PR DESCRIPTION
This PR adds functionality to the get apps endpoint to,
Query notebook apps.
Count the number of notebook apps in the metadata.
This enhancement improves the usability of the endpoint by providing more specific filtering and counting capabilities for notebook apps.
**How Can This Be Tested?**
Call the get apps endpoint with the appropriate query parameters to filter notebook apps by setting the Boolean to true.
Verify that the response includes only notebook apps and the correct count.
**Expected Results**
The endpoint should return only notebook apps when queried.