### PR TITLE
Filter generic search to return only a single user's apps and projects 

### DIFF
--- a/app/controllers/generic_search.py
+++ b/app/controllers/generic_search.py
@@ -2,6 +2,8 @@ from app.models.project import Project
 from app.models.app import App
 from app.models.user import User
 from app.models.tags import Tag
+from app.models.role import Role
+from app.models.project_users import ProjectUser
 from app.schemas.tags import TagListSchema
 from app.schemas.user import UserListSchema
 from app.schemas.project import ProjectListSchema
@@ -9,7 +11,7 @@ from app.schemas import AppSchema
 from flask import current_app
 from flask_restful import Resource, request
 from app.models.project import Project
-from flask_jwt_extended import jwt_required
+from flask_jwt_extended import jwt_required, get_jwt_identity, get_jwt_claims
 import json
 from sqlalchemy import or_
 
@@ -17,6 +19,10 @@ from sqlalchemy import or_
 class GenericSearchView(Resource):
     @jwt_required
     def get(self):
+
+        current_user_id = get_jwt_identity()
+        current_user_roles = get_jwt_claims()['roles']
+
         keywords = request.args.get('keywords', '')
         search_type = request.args.get('type', None)
 
@@ -35,6 +41,12 @@ class GenericSearchView(Resource):
         appSchema = AppSchema(many=True)
         userSchema = UserListSchema(many=True)
         tagSchema = TagListSchema(many=True)
+
+        is_admin = False
+        admin_role = Role.find_first(name='administrator')
+        
+        if admin_role and any(role['id'] == str(admin_role.id) for role in current_user_roles):
+            is_admin = True
 
         overall_pagination = {
             'total': 0,
@@ -70,12 +82,24 @@ class GenericSearchView(Resource):
 
         # Projects
         if not search_type or search_type == 'projects':
-            projects_pagination = Project.query.filter(
-                Project.name.ilike('%'+keywords+'%'),
-                # Project.is_public == True
-            ).order_by(Project.date_created.desc()).paginate(
-                page=int(page), per_page=int(per_page), error_out=False)
+            project_query = Project.query.filter(
+            Project.name.ilike('%'+keywords+'%')
+            )
+            if not is_admin:
+                project_query = project_query.filter(
+                    or_(
+                        Project.owner_id == current_user_id,
+                        Project.users.any(ProjectUser.user_id == current_user_id)
+                    )
+                )
+
+            projects_pagination = project_query.order_by(
+            Project.date_created.desc()
+            ).paginate(
+            page=int(page), per_page=int(per_page), error_out=False
+            )
             project_data, _ = projectSchema.dumps(projects_pagination.items)
+
             if projects_pagination.total > 0:
                 return_object['projects'] = {
                     'pagination': create_pagination(projects_pagination),
@@ -84,11 +108,26 @@ class GenericSearchView(Resource):
 
         # Apps
         if not search_type or search_type == 'apps':
-            apps_pagination = App.query.filter(
-                App.name.ilike('%'+keywords+'%')
-            ).order_by(App.date_created.desc()).paginate(
-                page=int(page), per_page=int(per_page), error_out=False)
+            app_query = App.query.filter(App.name.ilike('%'+keywords+'%'))
+
+            if not is_admin:
+                project_subquery = Project.query.with_entities(Project.id).filter(
+                    or_(
+                        Project.owner_id == current_user_id,
+                        Project.users.any(ProjectUser.user_id == current_user_id)
+                    )
+                ).subquery()
+
+                app_query = app_query.filter(App.project_id.in_(project_subquery))
+
+
+            apps_pagination = app_query.order_by(App.date_created.desc()).paginate(
+                page=int(page), 
+                per_page=int(per_page), 
+                error_out=False
+            )
             app_data, _ = appSchema.dumps(apps_pagination.items)
+
             if apps_pagination.total > 0:
                 return_object['apps'] = {
                     'pagination': create_pagination(apps_pagination),
@@ -100,7 +139,10 @@ class GenericSearchView(Resource):
             tags_pagination = Tag.query.filter(
                 Tag.name.ilike('%'+keywords+'%')
             ).order_by(Tag.date_created.desc()).paginate(
-                page=int(page), per_page=int(per_page), error_out=False)
+                page=int(page), 
+                per_page=int(per_page), 
+                error_out=False
+            )
             tags_data, _ = tagSchema.dumps(tags_pagination.items)
             if tags_pagination.total > 0:
                 return_object['tags'] = {

--- a/app/controllers/generic_search.py
+++ b/app/controllers/generic_search.py
@@ -83,7 +83,8 @@ class GenericSearchView(Resource):
         # Projects
         if not search_type or search_type == 'projects':
             project_query = Project.query.filter(
-            Project.name.ilike('%'+keywords+'%')
+                Project.name.ilike('%'+keywords+'%')
+                # Project.is_public == True
             )
             if not is_admin:
                 project_query = project_query.filter(
@@ -114,6 +115,7 @@ class GenericSearchView(Resource):
                 project_subquery = Project.query.with_entities(Project.id).filter(
                     or_(
                         Project.owner_id == current_user_id,
+                        # Project.is_public == True
                         Project.users.any(ProjectUser.user_id == current_user_id)
                     )
                 ).subquery()


### PR DESCRIPTION
# Description

This returns only resources for a single app if the user is not an admin user

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Trello Ticket ID

https://app.clickup.com/t/8699138n5

## How Can This Be Tested?

Run this branch and access the search endpoint where you should set off a query as admin and as a normal user
