### PR TITLE
Fix: Update k8s python client and enable multi container pod logs

### DIFF
--- a/app/controllers/app.py
+++ b/app/controllers/app.py
@@ -1801,18 +1801,64 @@ class AppLogsView(Resource):
         pods_logs = []
 
         for pod in podsList:
-            podLogs = kube_client.kube.read_namespaced_pod_log(
-                pod, namespace, pretty=True, tail_lines=tail_lines or 100,
-                timestamps=timestamps or False,
-                since_seconds=since_seconds or 86400
-            )
+            try:
+                # First, get pod details to check container count / catering for multi-container pods eg pods from seldon core
+                pod_details = kube_client.kube.read_namespaced_pod(pod, namespace)
+                containers = [container.name for container in pod_details.spec.containers]
+                
+                if len(containers) == 1:
+                    # Single container (use original method)
+                    podLogs = kube_client.kube.read_namespaced_pod_log(
+                        pod, namespace, pretty=True, tail_lines=tail_lines or 100,
+                        timestamps=timestamps or False,
+                        since_seconds=since_seconds or 86400
+                    )
 
-            if podLogs == '':
-                podLogs = kube_client.kube.read_namespaced_pod_log(
-                    pod, namespace, pretty=True, tail_lines=tail_lines or 100,
-                    timestamps=timestamps or False
-                )
-            pods_logs.append(podLogs)
+                    if podLogs == '':
+                        podLogs = kube_client.kube.read_namespaced_pod_log(
+                            pod, namespace, pretty=True, tail_lines=tail_lines or 100,
+                            timestamps=timestamps or False
+                        )
+                    pods_logs.append(podLogs)
+                    
+                else:
+                    # Multi-container (get logs from each container)
+                    combined_logs = []
+                    for container_name in containers:
+                        try:
+                            container_logs = kube_client.kube.read_namespaced_pod_log(
+                                pod, namespace, container=container_name,
+                                pretty=True, tail_lines=tail_lines or 100,
+                                timestamps=timestamps or False,
+                                since_seconds=since_seconds or 86400
+                            )
+                            
+                            if container_logs:
+                                combined_logs.append(f"=== Container: {container_name} ===")
+                                combined_logs.append(container_logs)
+                                combined_logs.append("=" * 50)
+                        except:
+                            # If container logs fail, try without since_seconds
+                            try:
+                                container_logs = kube_client.kube.read_namespaced_pod_log(
+                                    pod, namespace, container=container_name,
+                                    pretty=True, tail_lines=tail_lines or 100,
+                                    timestamps=timestamps or False
+                                )
+                                if container_logs:
+                                    combined_logs.append(f"=== Container: {container_name} ===")
+                                    combined_logs.append(container_logs)
+                                    combined_logs.append("=" * 50)
+                            except:
+                                combined_logs.append(f"=== Container: {container_name} ===")
+                                combined_logs.append("No logs available for this container")
+                                combined_logs.append("=" * 50)
+                    
+                    pods_logs.append("\n".join(combined_logs))
+                    
+            except Exception as e:
+                # Fallback for any other errors
+                pods_logs.append(f"Error retrieving logs for pod {pod}: {str(e)}")
 
         # Get failed pods infor
         for state in failed_pods:

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ jsonschema==2.6.0
 keyring==10.6.0
 keyrings.alt==3.0
 kombu==5.1.0
-kubernetes==23.3.0
+kubernetes==32.0.1
 Mako==1.1.6
 MarkupSafe==2.0.1
 marshmallow==2.19.2
@@ -52,7 +52,7 @@ mistune==2.0.3
 mysql-connector==2.2.9
 newrelic==7.16.0.178
 nose==1.3.7
-oauthlib==3.0.2
+oauthlib==3.2.2
 orjson==3.6.1
 packaging==21.3
 pluggy==1.0.0


### PR DESCRIPTION
# Description

This PR updates the python k8s clients in order to fix pod logs retireval. It also adds the functionality to get logs from multiple containers for multipod containers

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## Trello Ticket ID

https://app.clickup.com/t/8698wv4he

## How Can This Be Tested?

Run this branch and try to fetch app logs, you should also try to get seldon core app logs since they are multi container
NOTE: The K8s client has been updated, please test different endpoints as well to affirm no new issues are merged
