### PR TITLE
Return cluster information regardless of cluster connection failures

### DIFF
--- a/app/controllers/clusters.py
+++ b/app/controllers/clusters.py
@@ -142,6 +142,17 @@ class ClusterDetailView(Resource):
                     cluster=json.loads(validated_cluster_data),
                     resource_count=json.loads(resource_count_json))
             ), 200
+        
+        except client.rest.ApiException as e:
+            if e.status == 401 or "Unauthorized" in str(e):
+                return dict(
+                    status='fail',
+                    data=dict(
+                        cluster=json.loads(validated_cluster_data),
+                        resource_count=[]
+                    ),
+                    cluster_error="Could not access cluster or invalid token, please reset your cluster token."
+                ), 200
 
         except Exception as e:
             return dict(status='fail', message=str(e)), 500

--- a/app/controllers/clusters.py
+++ b/app/controllers/clusters.py
@@ -146,14 +146,7 @@ class ClusterDetailView(Resource):
         except client.rest.ApiException as e:
             error_message = "Could not access cluster or invalid token, please reset your cluster token." \
             if e.status == 401 or "Unauthorized" in str(e) else str(e)
-            return dict(
-            status='fail',
-            data=dict(
-                cluster=json.loads(validated_cluster_data),
-                resource_count=[]
-            ),
-            cluster_error=error_message
-            ), 200
+            return dict(status='fail', data=dict( cluster=json.loads(validated_cluster_data), resource_count=[]),cluster_error=error_message), 200
 
         except Exception as e:
             return dict(status='fail', message=str(e)), 500

--- a/app/controllers/clusters.py
+++ b/app/controllers/clusters.py
@@ -144,15 +144,16 @@ class ClusterDetailView(Resource):
             ), 200
         
         except client.rest.ApiException as e:
-            if e.status == 401 or "Unauthorized" in str(e):
-                return dict(
-                    status='fail',
-                    data=dict(
-                        cluster=json.loads(validated_cluster_data),
-                        resource_count=[]
-                    ),
-                    cluster_error="Could not access cluster or invalid token, please reset your cluster token."
-                ), 200
+            error_message = "Could not access cluster or invalid token, please reset your cluster token." \
+            if e.status == 401 or "Unauthorized" in str(e) else str(e)
+            return dict(
+            status='fail',
+            data=dict(
+                cluster=json.loads(validated_cluster_data),
+                resource_count=[]
+            ),
+            cluster_error=error_message
+            ), 200
 
         except Exception as e:
             return dict(status='fail', message=str(e)), 500


### PR DESCRIPTION
# Description

This PR enables the backend return cluster information regardless of cluster connection 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Trello Ticket ID

https://app.clickup.com/t/8699f5m75

## How Can This Be Tested?

Run this branch and try to fetch  a single cluster as admin
