### PR TITLE
fix: Update development compose file to use  official `cranecloud/cranecloud-backend` images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: ckwagaba/osprey-backend:latest
+    image: cranecloud/cranecloud-backend:latest
     container_name: flask-api
     networks:
       - cranecloud
@@ -84,7 +84,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: ckwagaba/osprey-backend:latest
+    image: cranecloud/cranecloud-backend:latest
     container_name: celery-worker
     command: celery -A server.celery worker --loglevel=info
     environment:


### PR DESCRIPTION


# Description

This PR adds updates the `docker-compose.yml` file to use `cranecloud/cranecloud-backend` instead of the non existent `ckwagaba/osprey-backend`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Trello Ticket ID

No trello Ticket ID for this issue

## How Can This Be Tested?

After merging the PR, you can try to run `make start` in a new environment, it will pull the `cranecloud/cranecloud-backend` image.
