### PR TITLE
add Google OAuth environment variables to staging config

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -124,6 +124,9 @@ jobs:
           --set environment.KUBE_SERVICE_PORT="${{ secrets.STAGING_KUBE_SERVICE_PORT }}" \
           --set environment.LOGGER_APP_URL="${{ secrets.MICROSERVICE_LOGGER_APP_URL }}" \
           --set environment.MLOPS_API_URL="${{ secrets.MICROSERVICE_MLOPS_API_URL }}" \
+          --set environment.GOOGLE_CLIENT_ID="${{ secrets.STAGING_GOOGLE_CLIENT_ID }}" \
+          --set environment.GOOGLE_CLIENT_SECRET="${{ secrets.STAGING_GOOGLE_CLIENT_SECRET }}" \
+          --set environment.GOOGLE_REDIRECT_URI="${{ secrets.STAGING_GOOGLE_REDIRECT_URI }}" \
           --timeout=300s
 
       - name: Monitor Rollout


### PR DESCRIPTION
Added environment variables for enabling Google OAuth authentication in the staging environment. This includes GOOGLE_CLIENT_ID
GOOGLE_CLIENT_SECRET
GOOGLE_REDIRECT_URI

