### PR TITLE
feat: add documentation and official and github URLs to Tag model and schema

### DIFF
--- a/app/controllers/tags.py
+++ b/app/controllers/tags.py
@@ -95,14 +95,13 @@ class TagsDetailView(Resource):
 
 
 class TagFollowingView(Resource):
-    @ jwt_required
+    @jwt_required
     def post(self, tag_id):
         current_user_id = get_jwt_identity()
         tag = Tag.get_by_id(tag_id)
 
         if not tag:
             return dict(status='fail', message=f'Tag with id {tag_id} not found'), 404
-
 
         existing_tag_follow = TagFollowers.find_first(
             user_id=current_user_id, tag_id=tag_id)
@@ -122,7 +121,7 @@ class TagFollowingView(Resource):
             message=f'You are now following tag with id {tag_id}'
         ), 201
 
-    @ jwt_required
+    @jwt_required
     def get(self, tag_id):
         tag = Tag.get_by_id(tag_id)
         follower_schema = UserIndexSchema(many=True)
@@ -138,7 +137,7 @@ class TagFollowingView(Resource):
             data=dict(followers=json.loads(users_data))
         ), 200
 
-    @ jwt_required
+    @jwt_required
     def delete(self, tag_id):
         current_user_id = get_jwt_identity()
         tag = Tag.get_by_id(tag_id)

--- a/app/models/tags.py
+++ b/app/models/tags.py
@@ -16,10 +16,12 @@ class Tag(ModelMixin):
     projects = db.relationship("ProjectTag", back_populates="tag")
     date_created = db.Column(db.DateTime, default=db.func.current_timestamp())
     followers = db.relationship('TagFollowers', back_populates='tag')
+    documentation_url = db.Column(db.String, nullable=True)
+    official_url = db.Column(db.String, nullable=True)
+    github_link = db.Column(db.String, nullable=True)
 
     def __repr__(self):
         return f"<Tag {self.name}>"
-
 
 
 class ProjectTag(ModelMixin):

--- a/app/schemas/tags.py
+++ b/app/schemas/tags.py
@@ -20,6 +20,9 @@ class TagSchema(Schema):
     date_created = fields.Date(dump_only=True)
     projects_count = fields.Method("get_projects_count", dump_only=True)
     is_following = fields.Method("get_is_following", dump_only=True)
+    documentation_url = fields.String(allow_none=True)
+    official_url = fields.String(allow_none=True)
+    github_link = fields.String(allow_none=True)
 
     def get_projects_count(self, obj):
         return len(obj.projects)


### PR DESCRIPTION
# Description

This PR adds `documentation_url`, `official_url` and `github_link`

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Trello Ticket ID

Please add a link to the Trello ticket for the task.

## How Can This Be Tested?

This can be tested by fetching a tag from via the API endpoint and verifying if `documentation_url`, `official_url` and `github_link` exist in the tags returned
