### PR TITLE
feat: return project pinned status to manage user projects on public view

### DIFF
--- a/app/controllers/project.py
+++ b/app/controllers/project.py
@@ -684,8 +684,8 @@ class UserProjectsView(Resource):
         # pagination_meta_data, projects = paginate(
         #     user.projects[::-1], per_page, page)
 
-        pagination = Project.query.filter(or_(Project.owner_id == current_user_id, Project.users.any(
-            ProjectUser.user_id == current_user_id))).order_by(Project.date_created.desc()).paginate(
+        pagination = Project.query.filter(or_(Project.owner_id == user_id, Project.users.any(
+            ProjectUser.user_id == user_id))).order_by(Project.date_created.desc()).paginate(
             page=page, per_page=per_page, error_out=False)
 
         projects = pagination.items

--- a/app/schemas/project.py
+++ b/app/schemas/project.py
@@ -70,6 +70,7 @@ class ProjectSchema(Schema):
     followers_count = fields.Method("get_followers_count", dump_only=True)
     members_count = fields.Method("get_members_count", dump_only=True)
     is_following = fields.Method("get_is_following", dump_only=True)
+    is_pinned = fields.Method("get_pinned_status", dump_only=True)
     is_public = fields.Boolean()
     tags = fields.Nested("TagsProjectsSchema", many=True, dump_only=True)
     tags_add = fields.List(fields.String, load_only=True)
@@ -102,6 +103,12 @@ class ProjectSchema(Schema):
     
     def get_tags_count(self, obj):
         return ProjectTag.count(project_id=obj.id)
+    
+    def get_pinned_status(self, obj):
+        project_user = ProjectUser.query.filter_by(
+            project_id=obj.id,
+        ).first()
+        return project_user.pinned if project_user else False
 
 
 class ProjectMigrationSchema(Schema):


### PR DESCRIPTION
# Description

- This PR aims to return the `pinned status` of a project to ease the implementation at the frontend for pinning and unpinning projects on a user profile. At the moment an array of pinned projects is returned but thats not enough and would need us to do more sorting on other projects that are not pinned in order for a user `pin/unpin` them.
- This PR also adjusts this endpoint - `GET[/users/{user_id}/projects]` that is meant to return projects on a user profiles visited in socials but at the moment it was just returning projects for the current user making the request regardless of the `user_id` passed to it.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## ClickUp Ticket ID

https://app.clickup.com/t/869abf3zf

## How Can This Be Tested?

- Run this PR locally and attempt to pin one or two projects, then using this route - `GET[/users/{user_id}/projects]` you will see the status reflecting accordingly.
