### PR TITLE
Feat/user following status

### DIFF
--- a/app/controllers/project_users.py
+++ b/app/controllers/project_users.py
@@ -1,7 +1,8 @@
 import json
 from app.models.project_users import ProjectUser
+from app.schemas.user import UserSchema
 from flask_restful import Resource, request
-from app.schemas import ProjectUserSchema, AnonymousUsersSchema, UserIndexSchema
+from app.schemas import ProjectUserSchema, AnonymousUsersSchema
 from app.models.user import User
 from app.models.role import User
 from app.models.project import Project
@@ -14,7 +15,7 @@ from app.helpers.user_role_update_notification import send_user_role_update_noti
 from app.helpers.activity_logger import log_activity
 from datetime import date
 from app.models.anonymous_users import AnonymousUser
-
+from app.models import db
 
 class ProjectUsersView(Resource):
 
@@ -547,20 +548,81 @@ class ProjectFollowingView(Resource):
 
     @ jwt_required
     def get(self, project_id):
+        page = request.args.get('page', 1, type=int)
+        per_page = request.args.get('per_page', 10, type=int)
+        
+        if per_page > 100:
+            per_page = 100
+            
+        if page < 1:
+            page = 1
+            
         project = Project.get_by_id(project_id)
-        follower_schema = UserIndexSchema(many=True)
-
-        followers = project.followers
-        users_data, errors = follower_schema.dumps(followers)
-
-        if errors:
-            return dict(status='fail', message=errors), 400
-
-        return dict(
-            status='success',
-            data=dict(followers=json.loads(users_data))
-        ), 200
-
+        
+        if not project:
+            return dict(status='fail', message=f'Project with id {project_id} not found'), 404
+            
+        try:
+            query = db.session.query(User).join(
+                ProjectFollowers, User.id == ProjectFollowers.user_id
+            ).filter(
+                ProjectFollowers.project_id == project_id
+            ).order_by(ProjectFollowers.id.desc())
+            
+            total_followers_count = query.count()
+            
+            paginated_result = query.paginate(
+                page=page,
+                per_page=per_page,
+                error_out=False
+            )
+            
+            follower_schema = UserSchema(many=True)
+            schema_result = follower_schema.dump(paginated_result.items)
+            
+            if hasattr(schema_result, 'data'):
+                followers_data = schema_result.data
+            else:
+                followers_data = schema_result
+                
+            if followers_data is None:
+                followers_data = []
+            elif not isinstance(followers_data, list):
+                try:
+                    followers_data = list(followers_data)
+                except:
+                    followers_data = []
+                    
+            pagination = {
+                'total': paginated_result.total,
+                'pages': paginated_result.pages,
+                'page': paginated_result.page,
+                'per_page': paginated_result.per_page,
+                'next': paginated_result.next_num,
+                'prev': paginated_result.prev_num,
+                'has_next': paginated_result.has_next,
+                'has_prev': paginated_result.has_prev
+            }
+            
+            project_info = dict(
+                id=str(project.id),
+                name=project.name,
+                alias=project.alias,
+                followers_count=total_followers_count
+            )
+            
+            return dict(
+                status='success',
+                data=dict(
+                    project=project_info,
+                    followers=followers_data,
+                    pagination=pagination
+                )
+            ), 200
+            
+        except Exception as e:
+            return dict(status='fail', message='Internal Server Error'), 500
+    
     @ jwt_required
     def delete(self, project_id):
         current_user_id = get_jwt_identity()

--- a/app/controllers/socials.py
+++ b/app/controllers/socials.py
@@ -130,6 +130,12 @@ class SocialService:
             user_schema = UserSchema(many=True)
             schema_result = user_schema.dump(users)
             users_data = SocialService._handle_schema_result(schema_result)
+            if current_user:
+                for user_data, user_obj in zip(users_data, users):
+                    user_data['is_following'] = current_user.is_following(user_obj)
+            else:
+                for user_data in users_data:
+                    user_data['is_following'] = False
             
             return {
                 'users': users_data,
@@ -149,6 +155,13 @@ class SocialService:
             user_schema = UserSchema(many=True)
             schema_result = user_schema.dump(users)
             users_data = SocialService._handle_schema_result(schema_result)
+
+            if current_user:
+                for user_data, user_obj in zip(users_data, users):
+                    user_data['is_following'] = current_user.is_following(user_obj)
+            else:
+                for user_data in users_data:
+                    user_data['is_following'] = False
             
             return users_data
 


### PR DESCRIPTION
# Description

This PR adds an `is_following` flag to the user data response in the `get_users_data` method. This boolean field indicates whether the currently authenticated user is following each user in the returned list.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Trello Ticket ID

Please add a link to the Trello ticket for the task.

## How Can This Be Tested?
**Test Scenario 1: Authenticated user with following relationships**
1. Log in as User A
2. Follow User B and User C (but not User D)
3. Make a GET request to the users endpoint
4. Verify the response includes `is_following: true` for User B and User C
5. Verify the response includes `is_following: false` for User D

**Test Scenario 2: Paginated results**
1. Log in as a user with multiple following relationships
2. Request users with pagination parameters (e.g., `page=1&per_page=5`)
3. Verify each user object has the `is_following` flag
4. Verify the flag accurately reflects the following status

**Test Scenario 3: Unauthenticated request**
1. Make a GET request to the users endpoint without authentication
2. Verify all users have `is_following: false`

**Test Scenario 4: With search and filters**
1. Log in as a user
2. Use search parameters (e.g., `search=john`)
3. Use filter types (e.g., `filter_type=trending`)
4. Verify `is_following` flag is present and accurate in all cases
