### PR TITLE
fix: the tag project veiw  endpoint not returning deleted projects

### DIFF
--- a/app/controllers/tags.py
+++ b/app/controllers/tags.py
@@ -254,7 +254,8 @@ class TagProjectsView(Resource):
             query = db.session.query(Project).join(
                 ProjectTag, Project.id == ProjectTag.project_id
             ).filter(
-                ProjectTag.tag_id == tag_id
+                ProjectTag.tag_id == tag_id,
+                Project.deleted.is_(False)
             ).order_by(Project.date_created.desc())
             total_projects_count = query.count()
             


### PR DESCRIPTION
# Description

This PR adds a soft delete filter to the tag projects query to ensure deleted projects are excluded from results.

**Change Made:**
- Added `Project.deleted.is_(False)` filter to the existing SQLAlchemy query in `TagProjectsView`
- This ensures that projects marked as deleted (soft delete) are not returned in tag-based project listings

**Motivation:**
The system uses soft deletion for projects, but the tag projects endpoint was previously returning all projects regardless of their deletion status. This could lead to users seeing projects that should no longer be visible.

## Type of change

- [] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Trello Ticket ID

[Add Trello card URL here if applicable]
Example: https://trello.com/c/abc123/fix-deleted-projects-showing-in-tag-listings

## How Can This Be Tested?

### Test Scenarios:



### Specific Test Cases:

1. **Active projects should appear:**
   - Project with `deleted = False` and associated with tag
   - Expected: Project appears in results

2. **Deleted projects should NOT appear:**
   - Project with `deleted = True` and associated with tag  
   - Expected: Project is filtered out


